### PR TITLE
fix Python 3.11 Type generic

### DIFF
--- a/worlds/okamihd/Types.py
+++ b/worlds/okamihd/Types.py
@@ -1,7 +1,5 @@
 import typing
-from typing import NamedTuple, Optional, List, Callable,TYPE_CHECKING
-
-from typing_extensions import TypeVar
+from typing import NamedTuple, Optional, List, Callable,TYPE_CHECKING, TypeVar
 
 from BaseClasses import Location, Item, ItemClassification, LocationProgressType, CollectionState
 from worlds.AutoWorld import World
@@ -69,9 +67,9 @@ class ExitData(NamedTuple):
     has_events: [str] = []
     needs_swim: bool = False
 
-
+T = TypeVar('T',str,int,bool)
 # Generic function to return the value or the resolved value of a callable that depends of options.
-def resolve_option_callable[T](value: T | Callable[[OkamiOptions], T], world: "OkamiWorld") -> T:
+def resolve_option_callable(value: T | Callable[[OkamiOptions], T], world: "OkamiWorld") -> T:
     if isinstance(value, Callable):
         return value(world.options)
     else:


### PR DESCRIPTION
## What is this fixing or adding?
Fix generation for Python 3.11

## How was this tested?
Installed python 3.1 and tested generation, the failing flake8 should now pass

## If this makes graphical changes, please attach screenshots.
