### PR TITLE
update IDs for client v0.8.0+

### DIFF
--- a/worlds/okamihd/CheckIds.py
+++ b/worlds/okamihd/CheckIds.py
@@ -1,0 +1,58 @@
+"""Archipelago check (location) ID encoding for Okami HD.
+
+This module is the Python mirror of the C++ check_types.hpp in
+the okami-apclient mod.
+
+ID range scheme: categories spaced 1e9 apart, within-category
+multiplier 1000.
+
+  - 1_000_000_000 + brushIndex                 Brush acquisitions
+  - 2_000_000_000 + shopId * 1000 + slot       Shop purchases
+  - 3_000_000_000 + mapId * 1000 + bitIndex    World state changes
+  - 4_000_000_000 + mapId * 1000 + bitIndex    Collected objects
+  - 5_000_000_000 + mapId * 1000 + bitIndex    Area restorations
+  - 6_000_000_000 + bitIndex                   Global flags
+  - 7_000_000_000 + bitIndex                   Game progress flags
+  - 8_000_000_000 + levelId * 1000 + spawnIdx  Container pickups
+"""
+
+BRUSH_BASE = 1_000_000_000
+SHOP_BASE = 2_000_000_000
+WORLD_STATE_BASE = 3_000_000_000
+COLLECTED_OBJECT_BASE = 4_000_000_000
+AREA_RESTORED_BASE = 5_000_000_000
+GLOBAL_FLAG_BASE = 6_000_000_000
+GAME_PROGRESS_BASE = 7_000_000_000
+CONTAINER_BASE = 8_000_000_000
+
+
+def brush_check_id(brush_index: int) -> int:
+    return BRUSH_BASE + brush_index
+
+
+def shop_check_id(shop_id: int, slot: int) -> int:
+    return SHOP_BASE + shop_id * 1000 + slot
+
+
+def world_state_check_id(map_id: int, bit_index: int) -> int:
+    return WORLD_STATE_BASE + map_id * 1000 + bit_index
+
+
+def collected_object_check_id(map_id: int, bit_index: int) -> int:
+    return COLLECTED_OBJECT_BASE + map_id * 1000 + bit_index
+
+
+def area_restored_check_id(map_id: int, bit_index: int) -> int:
+    return AREA_RESTORED_BASE + map_id * 1000 + bit_index
+
+
+def global_flag_check_id(bit_index: int) -> int:
+    return GLOBAL_FLAG_BASE + bit_index
+
+
+def game_progress_check_id(bit_index: int) -> int:
+    return GAME_PROGRESS_BASE + bit_index
+
+
+def container_check_id(level_id: int, spawn_idx: int) -> int:
+    return CONTAINER_BASE + level_id * 1000 + spawn_idx

--- a/worlds/okamihd/RegionsData/r101.py
+++ b/worlds/okamihd/RegionsData/r101.py
@@ -1,5 +1,6 @@
 from typing import TYPE_CHECKING
 
+from ..CheckIds import brush_check_id, container_check_id
 from ..Enums.BrushTechniques import BrushTechniques
 from ..Enums.LocationType import LocationType
 from ..Types import ExitData, LocData, EventData
@@ -26,10 +27,10 @@ events = {
 }
 locations = {
     RegionNames.CAVE_OF_NAGI: {
-        # Container IDs: 900000 + (0x101 << 8) + spawn_idx
-        "Cave of Nagi - Stray Bead Chest": LocData(965806),  # spawn_idx=14, Stray Bead
+        # Containers in this file are at level 0x101.
+        "Cave of Nagi - Stray Bead Chest": LocData(container_check_id(0x101, 14)),  # Stray Bead
     },
     RegionNames.CAVE_OF_NAGI_TACHIGAMI: {
-        "Cave of Nagi - Tachigami": LocData(200012, type=LocationType.CONSTELLATION),  # Brush acquisition (Power Slash, bit 12)
+        "Cave of Nagi - Tachigami": LocData(brush_check_id(12), type=LocationType.CONSTELLATION),  # Power Slash
     }
 }

--- a/worlds/okamihd/RegionsData/r102.py
+++ b/worlds/okamihd/RegionsData/r102.py
@@ -1,6 +1,7 @@
 from typing import TYPE_CHECKING
 
 from BaseClasses import LocationProgressType
+from ..CheckIds import brush_check_id, collected_object_check_id, container_check_id, shop_check_id
 from ..Enums.BrushTechniques import BrushTechniques
 from ..Enums.LocationType import LocationType
 from ..Enums.OkamiEnemies import OkamiEnemies
@@ -65,56 +66,54 @@ events = {
     }
 }
 locations = {
-    # Container IDs: 900000 + (0x102 << 8) + spawn_idx = 966048 + spawn_idx
     RegionNames.STONE_KAMIKI: {
-        "Kamiki Village - Sunrise": LocData(200027, type=LocationType.CONSTELLATION),  # Brush acquisition (bit 27)
+        "Kamiki Village - Sunrise": LocData(brush_check_id(27), type=LocationType.CONSTELLATION),  # Brush acquisition (bit 27)
     },
     RegionNames.KAMIKI_VILLAGE: {
-        "Kamiki Village - Chest After Mr.Orange Yokai Fight": LocData(966135),  # spawn_idx=87, Feedbag(Seeds)
-        "Kamiki Village - Buried Chest near Komuso": LocData(966048, type=LocationType.BURIED_CHEST),  # spawn_idx=0, Traveler's Charm
-        "Kamiki Village - Underwater Chest 1": LocData(966064, type=LocationType.UNDERWATER_CHEST_SHALLOW),  # spawn_idx=16, Rabbit Statue
-        "Kamiki Village - Underwater Chest 2": LocData(966081, type=LocationType.UNDERWATER_CHEST_SHALLOW),  # spawn_idx=33, Glass Beads
-        "Kamiki Village - Underwater chest in lake near Kushi's house": LocData(966080, type=LocationType.UNDERWATER_CHEST),  # spawn_idx=32, Vase
-        "Kamiki Village - Hasugami": LocData(200005, required_items_events=["Kamiki Village - Restore Sakuya's Tree"],
+        "Kamiki Village - Chest After Mr.Orange Yokai Fight": LocData(container_check_id(0x102, 87)),  # spawn_idx=87, Feedbag(Seeds)
+        "Kamiki Village - Buried Chest near Komuso": LocData(container_check_id(0x102, 0), type=LocationType.BURIED_CHEST),  # spawn_idx=0, Traveler's Charm
+        "Kamiki Village - Underwater Chest 1": LocData(container_check_id(0x102, 16), type=LocationType.UNDERWATER_CHEST_SHALLOW),  # spawn_idx=16, Rabbit Statue
+        "Kamiki Village - Underwater Chest 2": LocData(container_check_id(0x102, 33), type=LocationType.UNDERWATER_CHEST_SHALLOW),  # spawn_idx=33, Glass Beads
+        "Kamiki Village - Underwater chest in lake near Kushi's house": LocData(container_check_id(0x102, 32), type=LocationType.UNDERWATER_CHEST),  # spawn_idx=32, Vase
+        "Kamiki Village - Hasugami": LocData(brush_check_id(5), required_items_events=["Kamiki Village - Restore Sakuya's Tree"],
                                              type=LocationType.CONSTELLATION),  # Brush acquisition (Waterlily)
-        "Kamiki Village - Buried chest in field": LocData(966061, type=LocationType.BURIED_CHEST),  # spawn_idx=13, Dragonfly Bead
-        "Kamiki Village - Chest on Ledge": LocData(966057, required_brush_techniques=[BrushTechniques.GREENSPROUT_VINE]),  # spawn_idx=9, Exorcism Slip S
-        "Kamiki Village - Rafters Lower Chest": LocData(966059),  # spawn_idx=11, Stray Bead
-        "Kamiki Village - Rafters Upper Chest": LocData(966058, power_slash_level=1),  # spawn_idx=10, Glass Beads,
+        "Kamiki Village - Buried chest in field": LocData(container_check_id(0x102, 13), type=LocationType.BURIED_CHEST),  # spawn_idx=13, Dragonfly Bead
+        "Kamiki Village - Chest on Ledge": LocData(container_check_id(0x102, 9), required_brush_techniques=[BrushTechniques.GREENSPROUT_VINE]),  # spawn_idx=9, Exorcism Slip S
+        "Kamiki Village - Rafters Lower Chest": LocData(container_check_id(0x102, 11)),  # spawn_idx=11, Stray Bead
+        "Kamiki Village - Rafters Upper Chest": LocData(container_check_id(0x102, 10), power_slash_level=1),  # spawn_idx=10, Glass Beads,
         # West Island doesn't require long swim
-        "Kamiki Village - West Island chest ": LocData(966096),  # spawn_idx=48, Dragonfly Bead
-        "Kamiki Village - West Island buried chest": LocData(966102, type=LocationType.BURIED_CHEST),# spawn_idx=54, Wooden Bear
+        "Kamiki Village - West Island chest ": LocData(container_check_id(0x102, 48)),  # spawn_idx=48, Dragonfly Bead
+        "Kamiki Village - West Island buried chest": LocData(container_check_id(0x102, 54), type=LocationType.BURIED_CHEST),# spawn_idx=54, Wooden Bear
     },
     RegionNames.ORANGES_HOUSE: {
-        "Kamiki Village - Chest buried in Oranges' house": LocData(966067, type=LocationType.BURIED_CHEST),  # spawn_idx=19, Coral Fragment
+        "Kamiki Village - Chest buried in Oranges' house": LocData(container_check_id(0x102, 19), type=LocationType.BURIED_CHEST),  # spawn_idx=19, Coral Fragment
     },
     RegionNames.KUSHIS_HOUSE: {
         # Kushi's Gift is not a container - it's an event/NPC reward. Keep old ID for now.
-        "Kamiki Village - Kushi's Gift": LocData(500000 + 3 * 10000 + 11,  # mapId=3 (KamikiVillage enum index)
+        "Kamiki Village - Kushi's Gift": LocData(collected_object_check_id(3, 11),  # mapId=3 (KamikiVillage enum index)
                                                  required_items_events=["Kamiki Village - Repair Kushi's Watermill"]),
     },
     RegionNames.KAMIKI_ISLANDS: {
-        "Kamiki Village - East Islands Sun fragment chest": LocData(966090),  # spawn_idx=42, Sun Fragment
-        "Kamiki Village - East Islands Right Buried Chest": LocData(966055, type=LocationType.BURIED_CHEST),  # spawn_idx=7, Inkfinity Stone
-        "Kamiki Village - East Islands Left Buried Chest": LocData(966056, type=LocationType.BURIED_CHEST),  # spawn_idx=8, Stray Bead
+        "Kamiki Village - East Islands Sun fragment chest": LocData(container_check_id(0x102, 42)),  # spawn_idx=42, Sun Fragment
+        "Kamiki Village - East Islands Right Buried Chest": LocData(container_check_id(0x102, 7), type=LocationType.BURIED_CHEST),  # spawn_idx=7, Inkfinity Stone
+        "Kamiki Village - East Islands Left Buried Chest": LocData(container_check_id(0x102, 8), type=LocationType.BURIED_CHEST),  # spawn_idx=8, Stray Bead
     }
 }
 
-# Shop locations (shopId=5): 300000 + 5*1000 + slot = 305000 + slot
 # These are added separately and conditionally created based on RandomizeShops option
 shop_locations = {
     RegionNames.KAMIKI_MERCHANT: {
-        "Kamiki Village - Shop Slot 1": LocData(305000, type=LocationType.SHOP),
-        "Kamiki Village - Shop Slot 2": LocData(305001, type=LocationType.SHOP),
-        "Kamiki Village - Shop Slot 3": LocData(305002, type=LocationType.SHOP),
-        "Kamiki Village - Shop Slot 4": LocData(305003, type=LocationType.SHOP),
-        "Kamiki Village - Shop Slot 5": LocData(305004, type=LocationType.SHOP),
-        "Kamiki Village - Shop Slot 6": LocData(305005, type=LocationType.SHOP),
-        "Kamiki Village - Shop Slot 7": LocData(305006, type=LocationType.SHOP),
-        "Kamiki Village - Shop Slot 8": LocData(305007, type=LocationType.SHOP),
-        "Kamiki Village - Shop Slot 9": LocData(305008, type=LocationType.SHOP),
-        "Kamiki Village - Shop Slot 10": LocData(305009, type=LocationType.SHOP),
-        "Kamiki Village - Shop Slot 11": LocData(305010, type=LocationType.SHOP),
-        "Kamiki Village - Shop Slot 12": LocData(305011, type=LocationType.SHOP),
+        "Kamiki Village - Shop Slot 1": LocData(shop_check_id(5, 0), type=LocationType.SHOP),
+        "Kamiki Village - Shop Slot 2": LocData(shop_check_id(5, 1), type=LocationType.SHOP),
+        "Kamiki Village - Shop Slot 3": LocData(shop_check_id(5, 2), type=LocationType.SHOP),
+        "Kamiki Village - Shop Slot 4": LocData(shop_check_id(5, 3), type=LocationType.SHOP),
+        "Kamiki Village - Shop Slot 5": LocData(shop_check_id(5, 4), type=LocationType.SHOP),
+        "Kamiki Village - Shop Slot 6": LocData(shop_check_id(5, 5), type=LocationType.SHOP),
+        "Kamiki Village - Shop Slot 7": LocData(shop_check_id(5, 6), type=LocationType.SHOP),
+        "Kamiki Village - Shop Slot 8": LocData(shop_check_id(5, 7), type=LocationType.SHOP),
+        "Kamiki Village - Shop Slot 9": LocData(shop_check_id(5, 8), type=LocationType.SHOP),
+        "Kamiki Village - Shop Slot 10": LocData(shop_check_id(5, 9), type=LocationType.SHOP),
+        "Kamiki Village - Shop Slot 11": LocData(shop_check_id(5, 10), type=LocationType.SHOP),
+        "Kamiki Village - Shop Slot 12": LocData(shop_check_id(5, 11), type=LocationType.SHOP),
     }
 }

--- a/worlds/okamihd/RegionsData/r103.py
+++ b/worlds/okamihd/RegionsData/r103.py
@@ -1,5 +1,6 @@
 from typing import TYPE_CHECKING
 
+from ..CheckIds import brush_check_id, collected_object_check_id, container_check_id
 from ..Enums.BrushTechniques import BrushTechniques
 from ..Enums.LocationType import LocationType
 from ..Enums.OkamiEnemies import OkamiEnemies
@@ -26,19 +27,18 @@ events = {
     }
 }
 locations = {
-    # Container IDs: 900000 + (0x103 << 8) + spawn_idx = 966304 + spawn_idx
     RegionNames.CURSED_HANA_VALLEY: {
-        "Hana Valley - Freestanding Chest": LocData(966313),  # spawn_idx=9, Traveler's Charm
-        "Hana Valley - Buried chest near tunnel": LocData(966309, type=LocationType.BURIED_CHEST),  # spawn_idx=5, Stray Bead
-        "Hana Valley - Buried chest at entrance boulder": LocData(966310, type=LocationType.BURIED_CHEST),  # spawn_idx=6, Coral Fragment
+        "Hana Valley - Freestanding Chest": LocData(container_check_id(0x103, 9)),  # spawn_idx=9, Traveler's Charm
+        "Hana Valley - Buried chest near tunnel": LocData(container_check_id(0x103, 5), type=LocationType.BURIED_CHEST),  # spawn_idx=5, Stray Bead
+        "Hana Valley - Buried chest at entrance boulder": LocData(container_check_id(0x103, 6), type=LocationType.BURIED_CHEST),  # spawn_idx=6, Coral Fragment
     },
     RegionNames.HANA_VALLEY_SAKIGAMI: {
-        "Hana Valley - Sakigami": LocData(200004, type=LocationType.CONSTELLATION),  # Brush acquisition (Bloom)
+        "Hana Valley - Sakigami": LocData(brush_check_id(4), type=LocationType.CONSTELLATION),  # Brush acquisition (Bloom)
     },
     RegionNames.HANA_VALLEY: {
-        "Hana Valley - Chest on Island": LocData(966314),  # spawn_idx=10, Travel Guide: Digging Tips
+        "Hana Valley - Chest on Island": LocData(container_check_id(0x103, 10)),  # spawn_idx=10, Travel Guide: Digging Tips
         # Note: Sun Fragment chest (idx=80 in spreadsheet) may use a different system - keeping as collected object for now
-        "Hana Valley - Sun Fragment Chest (Bloom every Tree)": LocData(500000 + 4 * 10000 + 80,  # mapId=4 (HanaValley enum index)
+        "Hana Valley - Sun Fragment Chest (Bloom every Tree)": LocData(collected_object_check_id(4, 80),  # mapId=4 (HanaValley enum index)
             required_brush_techniques=[BrushTechniques.GREENSPROUT_BLOOM], power_slash_level=1),
     }
 }

--- a/worlds/okamihd/RegionsData/r104.py
+++ b/worlds/okamihd/RegionsData/r104.py
@@ -1,5 +1,6 @@
 from typing import TYPE_CHECKING
 
+from ..CheckIds import brush_check_id, container_check_id
 from ..Enums.BrushTechniques import BrushTechniques
 from ..Enums.LocationType import LocationType
 from ..Enums.OkamiEnemies import OkamiEnemies
@@ -76,44 +77,43 @@ events = {
     }
 }
 locations = {
-    # Container IDs: 900000 + (0x104 << 8) + spawn_idx = 966560 + spawn_idx
     RegionNames.TSUTA_RUINS_1F_MAIN_PART: {
-        "Tsuta Ruins - Freestanding Chest at Entrance": LocData(966577),  # spawn_idx=17, Travel Guide: Enhancing Divinity
-        "Tsuta Ruins - Treasure Bud in Entrance Hall Middle": LocData(966568, type=LocationType.TREASURE_BUD),  # spawn_idx=8, Traveler's Charm
-        "Tsuta Ruins - Treasure Bud in Entrance Hall Right Side": LocData(966569, type=LocationType.TREASURE_BUD),  # spawn_idx=9, Steel Soul Sake
-        "Tsuta Ruins - Chest in Entrance Hall near right side door": LocData(966586),  # spawn_idx=26, Vase
-        "Tsuta Ruins - Treasure Bud on 1F rightside path before ledge": LocData(966572, type=LocationType.TREASURE_BUD),  # spawn_idx=12, Steel Fist Sake
-        "Tsuta Ruins - Treasure Bud near glass ball": LocData(966560, type=LocationType.TREASURE_BUD),  # spawn_idx=0, Incense Burner
-        "Tsuta Ruins - Stray bead chest on 1F rightside path upper part": LocData(966575, required_brush_techniques=[
+        "Tsuta Ruins - Freestanding Chest at Entrance": LocData(container_check_id(0x104, 17)),  # spawn_idx=17, Travel Guide: Enhancing Divinity
+        "Tsuta Ruins - Treasure Bud in Entrance Hall Middle": LocData(container_check_id(0x104, 8), type=LocationType.TREASURE_BUD),  # spawn_idx=8, Traveler's Charm
+        "Tsuta Ruins - Treasure Bud in Entrance Hall Right Side": LocData(container_check_id(0x104, 9), type=LocationType.TREASURE_BUD),  # spawn_idx=9, Steel Soul Sake
+        "Tsuta Ruins - Chest in Entrance Hall near right side door": LocData(container_check_id(0x104, 26)),  # spawn_idx=26, Vase
+        "Tsuta Ruins - Treasure Bud on 1F rightside path before ledge": LocData(container_check_id(0x104, 12), type=LocationType.TREASURE_BUD),  # spawn_idx=12, Steel Fist Sake
+        "Tsuta Ruins - Treasure Bud near glass ball": LocData(container_check_id(0x104, 0), type=LocationType.TREASURE_BUD),  # spawn_idx=0, Incense Burner
+        "Tsuta Ruins - Stray bead chest on 1F rightside path upper part": LocData(container_check_id(0x104, 15), required_brush_techniques=[
             BrushTechniques.GREENSPROUT_VINE], type=LocationType.TREASURE_BUD),  # spawn_idx=15, Stray Bead
     },
     RegionNames.TSUTA_RUINS_MUSHROOMS: {
-        "Tsuta Ruins - Treasure bud behind logs in Mushrooms room": LocData(966562, power_slash_level=1,
+        "Tsuta Ruins - Treasure bud behind logs in Mushrooms room": LocData(container_check_id(0x104, 2), power_slash_level=1,
                                                                             type=LocationType.TREASURE_BUD),  # spawn_idx=2, Vengeance Slip
     },
     RegionNames.TSUTA_RUINS_LEFT_SIDE: {
-        "Tsuta Ruins - Treasure Bud behind hidden bombable wall on third plaform.": LocData(966561, cherry_bomb_level=1,
+        "Tsuta Ruins - Treasure Bud behind hidden bombable wall on third plaform.": LocData(container_check_id(0x104, 1), cherry_bomb_level=1,
                                                                                             type=LocationType.TREASURE_BUD),  # spawn_idx=1, Stray Bead
-        "Tsuta Ruins - Treasure Bud behind Lockjaw": LocData(966564, type=LocationType.TREASURE_BUD, required_items_events=[
+        "Tsuta Ruins - Treasure Bud behind Lockjaw": LocData(container_check_id(0x104, 4), type=LocationType.TREASURE_BUD, required_items_events=[
             "Tsuta Ruins - Open Lockjaw with Exorcising Arrow"]),  # spawn_idx=4, Exorcism Slip S
-        "Tsuta Ruins - Left side hidden treasure bud": LocData(966578, required_brush_techniques=[
+        "Tsuta Ruins - Left side hidden treasure bud": LocData(container_check_id(0x104, 18), required_brush_techniques=[
             BrushTechniques.GREENSPROUT_VINE], type=LocationType.TREASURE_BUD),  # spawn_idx=18, Golden Peach
     },
     RegionNames.TSUTA_RUINS_DEVIL_GATES: {
-        "Tsuta Ruins - Treasure Bud near Devil gates": LocData(966583, type=LocationType.TREASURE_BUD),  # spawn_idx=23, Lacquerware Set
-        "Tsuta Ruins - Treasure Bud #2 near Devil gates": LocData(966584, type=LocationType.TREASURE_BUD),  # spawn_idx=24, Holy Bone S
-        "Tsuta Ruins - Map Chest near poison pots": LocData(966594, required_items_events=[
+        "Tsuta Ruins - Treasure Bud near Devil gates": LocData(container_check_id(0x104, 23), type=LocationType.TREASURE_BUD),  # spawn_idx=23, Lacquerware Set
+        "Tsuta Ruins - Treasure Bud #2 near Devil gates": LocData(container_check_id(0x104, 24), type=LocationType.TREASURE_BUD),  # spawn_idx=24, Holy Bone S
+        "Tsuta Ruins - Map Chest near poison pots": LocData(container_check_id(0x104, 34), required_items_events=[
             "Tsuta Ruins - Grow Mushrooms in Devil Gates Room"]),  # spawn_idx=34, Tsuta Ruins Map
-        "Tsuta Ruins - Treasure Bud behind waterfall bombable wall": LocData(966585, required_items_events=[
+        "Tsuta Ruins - Treasure Bud behind waterfall bombable wall": LocData(container_check_id(0x104, 25), required_items_events=[
             "Tsuta Ruins - Destroy Poison Pots"], cherry_bomb_level=1, type=LocationType.TREASURE_BUD),  # spawn_idx=25, Stray Bead
     },
     RegionNames.TSUTA_RUINS_CENTRAL_STATUE: {
-        "Tsuta Ruins - Tsutagami": LocData(200019, required_items_events=[
+        "Tsuta Ruins - Tsutagami": LocData(brush_check_id(19), required_items_events=[
             "Tsuta Ruins - Bloom every cursed patch inside statue"], type=LocationType.CONSTELLATION),  # Brush acquisition (Vine, bit 19)
     },
     RegionNames.TSUTA_RUINS_SPIDER: {
-        "Tsuta Ruins - Left Chest before Spider queen": LocData(966581),  # spawn_idx=21, Travel Guide: Godhood Tips
-        "Tsuta Ruins - Right Chest before Spider queen": LocData(966582),  # spawn_idx=22, Holy Bone S
-        "Tsuta Ruins - Boss reward": LocData(966595, required_items_events=["Tsuta Ruins - Defeat the spider queen"]),  # spawn_idx=35, Bull Horn
+        "Tsuta Ruins - Left Chest before Spider queen": LocData(container_check_id(0x104, 21)),  # spawn_idx=21, Travel Guide: Godhood Tips
+        "Tsuta Ruins - Right Chest before Spider queen": LocData(container_check_id(0x104, 22)),  # spawn_idx=22, Holy Bone S
+        "Tsuta Ruins - Boss reward": LocData(container_check_id(0x104, 35), required_items_events=["Tsuta Ruins - Defeat the spider queen"]),  # spawn_idx=35, Bull Horn
     }
 }

--- a/worlds/okamihd/RegionsData/r107.py
+++ b/worlds/okamihd/RegionsData/r107.py
@@ -1,5 +1,6 @@
 from typing import TYPE_CHECKING
 
+from ..CheckIds import brush_check_id, container_check_id
 from ..Enums.BrushTechniques import BrushTechniques
 from ..Enums.LocationType import LocationType
 from ..Enums.OkamiEnemies import OkamiEnemies
@@ -60,38 +61,38 @@ events = {
 }
 locations = {
     RegionNames.GALE_SHRINE: {
-        "Gale Shrine - 1st Underwater Chest in entrance room": LocData(967354, type=LocationType.UNDERWATER_CHEST),
-        "Gale Shrine - 2nd Underwater Chest in entrance room": LocData(967355, type=LocationType.UNDERWATER_CHEST),
-        "Gale Shrine - 3rd Underwater Chest in entrance room": LocData(967356, type=LocationType.UNDERWATER_CHEST),
+        "Gale Shrine - 1st Underwater Chest in entrance room": LocData(container_check_id(0x107, 26), type=LocationType.UNDERWATER_CHEST),
+        "Gale Shrine - 2nd Underwater Chest in entrance room": LocData(container_check_id(0x107, 27), type=LocationType.UNDERWATER_CHEST),
+        "Gale Shrine - 3rd Underwater Chest in entrance room": LocData(container_check_id(0x107, 28), type=LocationType.UNDERWATER_CHEST),
     },
     RegionNames.GALE_SHRINE_LIFT: {
-        "Gale Shrine - 1st Chest Under Lift ": LocData(967350, required_items_events=["Gale Shrine - Use Lift"]),
-        "Gale Shrine - 2nd Chest Under Lift ": LocData(967351, required_items_events=["Gale Shrine - Use Lift"]),
-        "Gale Shrine - 3rd Chest Under Lift ": LocData(967352, required_items_events=["Gale Shrine - Use Lift"])
+        "Gale Shrine - 1st Chest Under Lift ": LocData(container_check_id(0x107, 22), required_items_events=["Gale Shrine - Use Lift"]),
+        "Gale Shrine - 2nd Chest Under Lift ": LocData(container_check_id(0x107, 23), required_items_events=["Gale Shrine - Use Lift"]),
+        "Gale Shrine - 3rd Chest Under Lift ": LocData(container_check_id(0x107, 24), required_items_events=["Gale Shrine - Use Lift"])
     },
     RegionNames.GALE_SHRINE_2F: {
-        "Gale Shrine - 2F Burning Chest": LocData(967330, type=LocationType.BURNING_CHEST_NO_WATER)
+        "Gale Shrine - 2F Burning Chest": LocData(container_check_id(0x107, 2), type=LocationType.BURNING_CHEST_NO_WATER)
     },
     RegionNames.GALE_SHRINE_3F: {
-        "Gale Shrine - Kazegami": LocData(200006, type=LocationType.CONSTELLATION),  # bit 6
-        "Gale Shrine - 3F Sun Fragment chest near Kazegami": LocData(967328),
-        "Gale Shrine - 3F Burning Chest": LocData(967329, type=LocationType.BURNING_CHEST_NO_WATER)
+        "Gale Shrine - Kazegami": LocData(brush_check_id(6), type=LocationType.CONSTELLATION),  # bit 6
+        "Gale Shrine - 3F Sun Fragment chest near Kazegami": LocData(container_check_id(0x107, 0)),
+        "Gale Shrine - 3F Burning Chest": LocData(container_check_id(0x107, 1), type=LocationType.BURNING_CHEST_NO_WATER)
     },
     RegionNames.GALE_SHRINE_BACK: {
-        "Gale Shrine - 1F Chest after windmills": LocData(967346),
-        "Gale Shrine - 1F Burning Chest in banner room": LocData(967344, type=LocationType.BURNING_CHEST_NO_WATER),
-        "Gale Shrine - 1F Burning Chest in banner room rafters center": LocData(967345,
+        "Gale Shrine - 1F Chest after windmills": LocData(container_check_id(0x107, 18)),
+        "Gale Shrine - 1F Burning Chest in banner room": LocData(container_check_id(0x107, 16), type=LocationType.BURNING_CHEST_NO_WATER),
+        "Gale Shrine - 1F Burning Chest in banner room rafters center": LocData(container_check_id(0x107, 17),
                                                                                 type=LocationType.BURNING_CHEST_NO_WATER,
                                                                                 required_brush_techniques=[
                                                                                     BrushTechniques.GREENSPROUT_VINE]),
-        "Gale Shrine - 1F Burning Chest in banner room rafters front": LocData(967347,
+        "Gale Shrine - 1F Burning Chest in banner room rafters front": LocData(container_check_id(0x107, 19),
                                                                                type=LocationType.BURNING_CHEST_NO_WATER,
                                                                                required_brush_techniques=[
                                                                                    BrushTechniques.GREENSPROUT_VINE]),
-        "Gale Shrine - 1F Chest in banner room rafters top": LocData(967348,
+        "Gale Shrine - 1F Chest in banner room rafters top": LocData(container_check_id(0x107, 20),
                                                                      required_brush_techniques=[
                                                                          BrushTechniques.GREENSPROUT_VINE]),
-        "Gale Shrine - 1F Chest in banner room between banners": LocData(967349,
+        "Gale Shrine - 1F Chest in banner room between banners": LocData(container_check_id(0x107, 21),
                                                                          required_brush_techniques=[
                                                                              BrushTechniques.GALESTORM]),
         "Gale Shrine - 1F Chest in banner room after banners": LocData(169,
@@ -99,6 +100,6 @@ locations = {
                                                                            BrushTechniques.GALESTORM])
     },
     RegionNames.GALE_SHRINE_BOSS:{
-        "Gale Shrine - Crimson Helm Reward": LocData(967353, required_items_events=["Gale Shrine - Defeat Crimson Helm"])
+        "Gale Shrine - Crimson Helm Reward": LocData(container_check_id(0x107, 25), required_items_events=["Gale Shrine - Defeat Crimson Helm"])
     }
 }

--- a/worlds/okamihd/RegionsData/r108.py
+++ b/worlds/okamihd/RegionsData/r108.py
@@ -1,6 +1,7 @@
 from typing import TYPE_CHECKING
 
 from BaseClasses import LocationProgressType
+from ..CheckIds import container_check_id
 from ..Enums.BrushTechniques import BrushTechniques
 from ..Enums.LocationType import LocationType
 from ..Enums.OkamiEnemies import OkamiEnemies
@@ -51,28 +52,28 @@ events = {
 }
 locations = {
     RegionNames.KUSA_VILLAGE: {
-        "Kusa Village - Chest on rafters after banners": LocData(967595,
+        "Kusa Village - Chest on rafters after banners": LocData(container_check_id(0x108, 11),
                                                                  required_brush_techniques=[BrushTechniques.GALESTORM,
                                                                                             BrushTechniques.GREENSPROUT_VINE]),
-        "Kusa Village - Chest on rafters before banners": LocData(967626,
+        "Kusa Village - Chest on rafters before banners": LocData(container_check_id(0x108, 42),
                                                                   required_brush_techniques=[
                                                                       BrushTechniques.GREENSPROUT_VINE]),
-        "Kusa Village - Stray Bead Chest on rafters after banners": LocData(967627,
+        "Kusa Village - Stray Bead Chest on rafters after banners": LocData(container_check_id(0x108, 43),
                                                                             required_brush_techniques=[
                                                                                 BrushTechniques.GALESTORM,
                                                                                 BrushTechniques.GREENSPROUT_VINE]),
-        "Kusa Village - Buried Chest near Fuse's house": LocData(967637, type=LocationType.BURIED_CHEST),
-        "Kusa Village - Buried Chest near Gale Shrine Ledge": LocData(967642, type=LocationType.BURIED_CHEST),
-        "Kusa Village - Underwater Chest near Fuse's house right": LocData(967654, type=LocationType.UNDERWATER_CHEST),
-        "Kusa Village - Underwater Chest near Fuse's house left": LocData(967655, type=LocationType.UNDERWATER_CHEST)
+        "Kusa Village - Buried Chest near Fuse's house": LocData(container_check_id(0x108, 53), type=LocationType.BURIED_CHEST),
+        "Kusa Village - Buried Chest near Gale Shrine Ledge": LocData(container_check_id(0x108, 58), type=LocationType.BURIED_CHEST),
+        "Kusa Village - Underwater Chest near Fuse's house right": LocData(container_check_id(0x108, 70), type=LocationType.UNDERWATER_CHEST),
+        "Kusa Village - Underwater Chest near Fuse's house left": LocData(container_check_id(0x108, 71), type=LocationType.UNDERWATER_CHEST)
     },
     RegionNames.KUSA_INN: {
-        "Kusa Village - Daruma inside Inn": LocData(967652, type=LocationType.DARUMA)
+        "Kusa Village - Daruma inside Inn": LocData(container_check_id(0x108, 68), type=LocationType.DARUMA)
     },
     RegionNames.KUSA_VILLAGE_BLOCKHEAD: {
-        "Kusa Village - Chest inside Blockhead Cave": LocData(967594)
+        "Kusa Village - Chest inside Blockhead Cave": LocData(container_check_id(0x108, 10))
     },
     RegionNames.BAMBOO_HOUSE: {
-        "Kusa Village - Buried Chest inside Mr Bamboo's house": LocData(967631, type=LocationType.BURIED_CHEST)
+        "Kusa Village - Buried Chest inside Mr Bamboo's house": LocData(container_check_id(0x108, 47), type=LocationType.BURIED_CHEST)
     }
 }

--- a/worlds/okamihd/RegionsData/r109.py
+++ b/worlds/okamihd/RegionsData/r109.py
@@ -1,6 +1,7 @@
 from typing import TYPE_CHECKING
 
 from BaseClasses import LocationProgressType
+from ..CheckIds import brush_check_id, container_check_id
 from ..Enums.BrushTechniques import BrushTechniques
 from ..Enums.LocationType import LocationType
 from ..Enums.OkamiEnemies import OkamiEnemies
@@ -35,26 +36,26 @@ events = {
 }
 locations = {
     RegionNames.SASA_SANCTUARY_ENTRANCE: {
-        "Sasa Sanctuary - Buried Chest near Entrance": LocData(967880, type=LocationType.BURIED_CHEST)
+        "Sasa Sanctuary - Buried Chest near Entrance": LocData(container_check_id(0x109, 40), type=LocationType.BURIED_CHEST)
     },
     RegionNames.SASA_SANCTUARY: {
-        "Sasa Sanctuary - 4th West side chest near Papa Jamba": LocData(967840, type=LocationType.NORMAL_CHEST),
-        "Sasa Sanctuary - 2nd West side chest near Papa Jamba": LocData(967841, type=LocationType.NORMAL_CHEST),
-        "Sasa Sanctuary - 5th East side chest near Papa Jamba": LocData(967842, type=LocationType.NORMAL_CHEST),
-        "Sasa Sanctuary - 3rd East side chest near Papa Jamba": LocData(967843, type=LocationType.NORMAL_CHEST),
-        "Sasa Sanctuary - 1st East side chest near Papa Jamba": LocData(967844, type=LocationType.NORMAL_CHEST),
-        "Sasa Sanctuary - 4th East side chest near Papa Jamba": LocData(967860, type=LocationType.NORMAL_CHEST),
-        "Sasa Sanctuary - 2nd East side chest near Papa Jamba": LocData(967861, type=LocationType.NORMAL_CHEST),
-        "Sasa Sanctuary - 5th West side chest near Papa Jamba": LocData(967862, type=LocationType.NORMAL_CHEST),
-        "Sasa Sanctuary - 3rd West side chest near Papa Jamba": LocData(967863, type=LocationType.NORMAL_CHEST),
-        "Sasa Sanctuary - 1st West side chest near Papa Jamba": LocData(967864, type=LocationType.NORMAL_CHEST),
-        "Sasa Sanctuary - Buried Chest near hot springs": LocData(967881, type=LocationType.BURIED_CHEST),
-        "Sasa Sanctuary - Nuregami": LocData(200013, type=LocationType.CONSTELLATION),  # bit 13
-        "Sasa Sanctuary - Daruma Doll": LocData(967883, type=LocationType.DARUMA)
+        "Sasa Sanctuary - 4th West side chest near Papa Jamba": LocData(container_check_id(0x109, 0), type=LocationType.NORMAL_CHEST),
+        "Sasa Sanctuary - 2nd West side chest near Papa Jamba": LocData(container_check_id(0x109, 1), type=LocationType.NORMAL_CHEST),
+        "Sasa Sanctuary - 5th East side chest near Papa Jamba": LocData(container_check_id(0x109, 2), type=LocationType.NORMAL_CHEST),
+        "Sasa Sanctuary - 3rd East side chest near Papa Jamba": LocData(container_check_id(0x109, 3), type=LocationType.NORMAL_CHEST),
+        "Sasa Sanctuary - 1st East side chest near Papa Jamba": LocData(container_check_id(0x109, 4), type=LocationType.NORMAL_CHEST),
+        "Sasa Sanctuary - 4th East side chest near Papa Jamba": LocData(container_check_id(0x109, 20), type=LocationType.NORMAL_CHEST),
+        "Sasa Sanctuary - 2nd East side chest near Papa Jamba": LocData(container_check_id(0x109, 21), type=LocationType.NORMAL_CHEST),
+        "Sasa Sanctuary - 5th West side chest near Papa Jamba": LocData(container_check_id(0x109, 22), type=LocationType.NORMAL_CHEST),
+        "Sasa Sanctuary - 3rd West side chest near Papa Jamba": LocData(container_check_id(0x109, 23), type=LocationType.NORMAL_CHEST),
+        "Sasa Sanctuary - 1st West side chest near Papa Jamba": LocData(container_check_id(0x109, 24), type=LocationType.NORMAL_CHEST),
+        "Sasa Sanctuary - Buried Chest near hot springs": LocData(container_check_id(0x109, 41), type=LocationType.BURIED_CHEST),
+        "Sasa Sanctuary - Nuregami": LocData(brush_check_id(13), type=LocationType.CONSTELLATION),  # bit 13
+        "Sasa Sanctuary - Daruma Doll": LocData(container_check_id(0x109, 43), type=LocationType.DARUMA)
     },
     RegionNames.SASA_SANCTUARY_BAMBOO: {
-        "Sasa Sanctuary - Buried Chest in bamboo grove stairs": LocData(967882, type=LocationType.BURIED_CHEST),
-        "Sasa Sanctuary - Left side Buried Chest in bamboo grove back": LocData(967886, type=LocationType.BURIED_CHEST),
-        "Sasa Sanctuary - Right side Buried Chest in bamboo grove back": LocData(967885, type=LocationType.BURIED_CHEST),
+        "Sasa Sanctuary - Buried Chest in bamboo grove stairs": LocData(container_check_id(0x109, 42), type=LocationType.BURIED_CHEST),
+        "Sasa Sanctuary - Left side Buried Chest in bamboo grove back": LocData(container_check_id(0x109, 46), type=LocationType.BURIED_CHEST),
+        "Sasa Sanctuary - Right side Buried Chest in bamboo grove back": LocData(container_check_id(0x109, 45), type=LocationType.BURIED_CHEST),
     }
 }

--- a/worlds/okamihd/RegionsData/r10e.py
+++ b/worlds/okamihd/RegionsData/r10e.py
@@ -1,5 +1,6 @@
 from typing import TYPE_CHECKING
 
+from ..CheckIds import container_check_id
 from ..Enums.LocationType import LocationType
 from ..Enums.RegionNames import RegionNames
 from ..Types import ExitData, LocData, EventData
@@ -20,10 +21,10 @@ events={
 }
 locations={
     RegionNames.CALCIFIED_CAVERN: {
-        "Calcified Cavern - Freestanding item": LocData(969120, type=LocationType.FREESTANDING_ITEM),
+        "Calcified Cavern - Freestanding item": LocData(container_check_id(0x10E, 0), type=LocationType.FREESTANDING_ITEM),
         #For now this is treated like a key, so not randomized.
-        #"Calcified Cavern - Chest after devil gate": LocData(969121, required_items_events=["Calcified Cavern - Defeat devil gate"]),
-        "Calcified Cavern - Left Side chest":LocData(969122),
-        "Calcified Cavern - Frozen Chest": LocData(969123,type=LocationType.FROZEN_CHEST)
+        #"Calcified Cavern - Chest after devil gate": LocData(container_check_id(0x10E, 1), required_items_events=["Calcified Cavern - Defeat devil gate"]),
+        "Calcified Cavern - Left Side chest":LocData(container_check_id(0x10E, 2)),
+        "Calcified Cavern - Frozen Chest": LocData(container_check_id(0x10E, 3),type=LocationType.FROZEN_CHEST)
     }
 }

--- a/worlds/okamihd/RegionsData/r110.py
+++ b/worlds/okamihd/RegionsData/r110.py
@@ -1,5 +1,6 @@
 from typing import TYPE_CHECKING
 
+from ..CheckIds import brush_check_id, container_check_id
 from ..Enums.BrushTechniques import BrushTechniques
 from ..Enums.LocationType import LocationType
 from ..Enums.OkamiEnemies import OkamiEnemies
@@ -163,51 +164,51 @@ events = {
 #TODO: Check basment chest, there's probably one or two missing
 locations = {
     RegionNames.MOON_CAVE: {
-        "Moon Cave - 1F Chest on ledge in the kitchen": LocData(969640),
-        "Moon Cave - 1F Frozen Chest after 3 ingredients": LocData(969639, type=LocationType.FROZEN_CHEST, special_rule=
+        "Moon Cave - 1F Chest on ledge in the kitchen": LocData(container_check_id(0x110, 8)),
+        "Moon Cave - 1F Frozen Chest after 3 ingredients": LocData(container_check_id(0x110, 7), type=LocationType.FROZEN_CHEST, special_rule=
             lambda s, w: has_soup_ingerdients(s, w, 3) ),
-        "Moon Cave - 1F Chest after 4 ingredients": LocData(969642,
+        "Moon Cave - 1F Chest after 4 ingredients": LocData(container_check_id(0x110, 10),
                                                             special_rule=(lambda s, w: has_soup_ingerdients(s, w, 4))),
     },
     RegionNames.MOON_CAVE_1F_LOCKED_CAVE: {
         "Moon Cave - 1F locked cave Treasure bud behind bombable wall": LocData(176, type=LocationType.TREASURE_BUD)
     },
     RegionNames.MOON_CAVE_B2F_LIFT: {
-        "Moon Cave - B2F Chest on ledge near eyes door": LocData(969647)
+        "Moon Cave - B2F Chest on ledge near eyes door": LocData(container_check_id(0x110, 15))
     },
     RegionNames.MOON_CAVE_B2F_FROZEN_STATUE: {
-        "Moon Cave - Moegami": LocData(200010, type=LocationType.CONSTELLATION)  # bit 10
+        "Moon Cave - Moegami": LocData(brush_check_id(10), type=LocationType.CONSTELLATION)  # bit 10
     },
     RegionNames.MOON_CAVE_B2F_BOMBABLE: {
-        "Moon Cave - B2F Chest behind bombable wall": LocData(969636)
+        "Moon Cave - B2F Chest behind bombable wall": LocData(container_check_id(0x110, 4))
     },
     RegionNames.MOON_CAVE_2F_SAND: {
         # Made this logically require cherry bomb as it's required to exit this area.
-        "Moon Cave - 2F Chest in sand pit": LocData(969648, cherry_bomb_level=1),
-        "Moon Cave - 2F Map Chest after ball puzzle": LocData(969637)
+        "Moon Cave - 2F Chest in sand pit": LocData(container_check_id(0x110, 16), cherry_bomb_level=1),
+        "Moon Cave - 2F Map Chest after ball puzzle": LocData(container_check_id(0x110, 5))
     },
     RegionNames.MOON_CAVE_2F_3F_RAFTERS: {
-        "Moon Cave - 3F Frozen Chest near merchant": LocData(969644, type=LocationType.FROZEN_CHEST, special_rule=lambda s, w: moon_cave_fire_rule(s, w)),
-        "Moon Cave - 2F Rafters Chest under 3F Rafters": LocData(969643),
+        "Moon Cave - 3F Frozen Chest near merchant": LocData(container_check_id(0x110, 12), type=LocationType.FROZEN_CHEST, special_rule=lambda s, w: moon_cave_fire_rule(s, w)),
+        "Moon Cave - 2F Rafters Chest under 3F Rafters": LocData(container_check_id(0x110, 11)),
     },
     RegionNames.MOON_CAVE_2F_FIRE_EYE: {
-        "Moon Cave - 2F Left Frozen Chest after Fire eye room": LocData(969651,
+        "Moon Cave - 2F Left Frozen Chest after Fire eye room": LocData(container_check_id(0x110, 19),
                                                                         type=LocationType.FROZEN_CHEST,
                                                                         special_rule=lambda s, w: moon_cave_fire_rule(s,
                                                                                                                       w)),
-        "Moon Cave - 2F Middle Frozen Chest after Fire eye room": LocData(969649,
+        "Moon Cave - 2F Middle Frozen Chest after Fire eye room": LocData(container_check_id(0x110, 17),
                                                                           type=LocationType.FROZEN_CHEST,
                                                                           special_rule=lambda s, w: moon_cave_fire_rule(s,
                                                                                                                       w)),
-        "Moon Cave - 2F Right Frozen Chest after Fire eye room": LocData(969650,
+        "Moon Cave - 2F Right Frozen Chest after Fire eye room": LocData(container_check_id(0x110, 18),
                                                                          type=LocationType.FROZEN_CHEST,
                                                                          special_rule=lambda s, w: moon_cave_fire_rule(s,
                                                                                                                       w)),
     },
     RegionNames.MOON_CAVE_4F_AFTER_CANON: {
-        "Moon Cave - 4F Lower ledge Frozen Chest": LocData(969652, type=LocationType.FROZEN_CHEST,
+        "Moon Cave - 4F Lower ledge Frozen Chest": LocData(container_check_id(0x110, 20), type=LocationType.FROZEN_CHEST,
                                                            special_rule=lambda s, w: moon_cave_fire_rule_4f(s, w)),
-        "Moon Cave - 4F Upper ledge Frozen Chest": LocData(969653, type=LocationType.FROZEN_CHEST,
+        "Moon Cave - 4F Upper ledge Frozen Chest": LocData(container_check_id(0x110, 21), type=LocationType.FROZEN_CHEST,
                                                            special_rule=lambda s, w: moon_cave_fire_rule_4f(s, w))
     }
 }

--- a/worlds/okamihd/RegionsData/r122.py
+++ b/worlds/okamihd/RegionsData/r122.py
@@ -1,5 +1,6 @@
 from typing import TYPE_CHECKING
 
+from ..CheckIds import brush_check_id, container_check_id
 from ..Enums.BrushTechniques import BrushTechniques
 from ..Enums.LocationType import LocationType
 from ..Enums.RegionNames import RegionNames
@@ -24,11 +25,10 @@ events = {
 }
 locations = {
     RegionNames.RIVER_OF_THE_HEAVENS_KAMIKI: {
-        # Container IDs: 900000 + (0x122 << 8) + spawn_idx
-        "River of the Heavens - Ledge Chest": LocData(974240),  # spawn_idx=0, Holy Bone S
-        "River of the Heavens - Yomigami": LocData(200022, type=LocationType.CONSTELLATION),  # Brush acquisition (bit 22)
+        "River of the Heavens - Ledge Chest": LocData(container_check_id(0x122, 0)),  # spawn_idx=0, Holy Bone S
+        "River of the Heavens - Yomigami": LocData(brush_check_id(22), type=LocationType.CONSTELLATION),  # Brush acquisition (bit 22)
     },
     RegionNames.RIVER_OF_THE_HEAVENS_NAGI: {
-        "River of the Heavens - Astral Pouch": LocData(974252),  # spawn_idx=12, Astral Pouch
+        "River of the Heavens - Astral Pouch": LocData(container_check_id(0x122, 12)),  # spawn_idx=12, Astral Pouch
     }
 }

--- a/worlds/okamihd/RegionsData/rf02.py
+++ b/worlds/okamihd/RegionsData/rf02.py
@@ -1,5 +1,6 @@
 from typing import TYPE_CHECKING
 
+from ..CheckIds import brush_check_id, container_check_id, shop_check_id
 from ..Enums.BrushTechniques import BrushTechniques
 from ..Enums.LocationType import LocationType
 from ..Enums.OkamiEnemies import OkamiEnemies
@@ -25,52 +26,51 @@ events = {
 }
 locations = {
     RegionNames.SHINSHU_FIELD: {
-        "Shinshu Field - Buried chest near Guardian Sapling": LocData(1883559, type=LocationType.BURIED_CHEST),
-        "Shinshu Field - Freestanding chest behind Guardian Sapling": LocData(1883563),
-        "Shinshu Field - Buried chest near Tama's house": LocData(1883578, type=LocationType.BURIED_CHEST),
-        "Shinshu Field - Buried chest near Lake": LocData(1883582, type=LocationType.BURIED_CHEST),
-        "Shinshu Field - Chest Under Bombable ground near Agata Forest": LocData(1883588, cherry_bomb_level=1,
+        "Shinshu Field - Buried chest near Guardian Sapling": LocData(container_check_id(0xF02, 7), type=LocationType.BURIED_CHEST),
+        "Shinshu Field - Freestanding chest behind Guardian Sapling": LocData(container_check_id(0xF02, 11)),
+        "Shinshu Field - Buried chest near Tama's house": LocData(container_check_id(0xF02, 26), type=LocationType.BURIED_CHEST),
+        "Shinshu Field - Buried chest near Lake": LocData(container_check_id(0xF02, 30), type=LocationType.BURIED_CHEST),
+        "Shinshu Field - Chest Under Bombable ground near Agata Forest": LocData(container_check_id(0xF02, 36), cherry_bomb_level=1,
                                                                                  required_brush_techniques=[
                                                                                      BrushTechniques.GREENSPROUT_BLOOM]),
-        "Shinshu Field - Buried chest near Dojo": LocData(1883594, type=LocationType.BURIED_CHEST),
-        "Shinshu Field - Chest after devil gate": LocData(1883599, mandatory_enemies=[OkamiEnemies.GREEN_IMP,
+        "Shinshu Field - Buried chest near Dojo": LocData(container_check_id(0xF02, 42), type=LocationType.BURIED_CHEST),
+        "Shinshu Field - Chest after devil gate": LocData(container_check_id(0xF02, 47), mandatory_enemies=[OkamiEnemies.GREEN_IMP,
                                                                                  OkamiEnemies.RED_IMP,
                                                                                  OkamiEnemies.YELLOW_IMP]),
         # Probably should find a better name for this one
-        "Shinshu Field - Buried chest on ledge": LocData(1883602, type=LocationType.BURIED_CHEST),
-        "Shinshu Field - Buried chest near Ovens": LocData(1883630, type=LocationType.BURIED_CHEST),
+        "Shinshu Field - Buried chest on ledge": LocData(container_check_id(0xF02, 50), type=LocationType.BURIED_CHEST),
+        "Shinshu Field - Buried chest near Ovens": LocData(container_check_id(0xF02, 78), type=LocationType.BURIED_CHEST),
         # This is the cherry bomb tutorial. Need to check what happens if you blow the wall before doing the tutorial.
-        "Shinshu Field - In Bombable cave near Tama's house": LocData(1883634, cherry_bomb_level=1),
-        "Shinshu Field - In Bombable cave near cat statue": LocData(1883635, cherry_bomb_level=1),
-        "Shinshu Field - Buried Chest in leaf pile near Tama's house": LocData(1883638,
+        "Shinshu Field - In Bombable cave near Tama's house": LocData(container_check_id(0xF02, 82), cherry_bomb_level=1),
+        "Shinshu Field - In Bombable cave near cat statue": LocData(container_check_id(0xF02, 83), cherry_bomb_level=1),
+        "Shinshu Field - Buried Chest in leaf pile near Tama's house": LocData(container_check_id(0xF02, 86),
                                                                                type=LocationType.BURIED_UNDER_LEAF_PILE),
-        "Shinshu Field - Chest on Big Torii": LocData(1883641, required_brush_techniques=[BrushTechniques.WATERSPOUT]),
-        "Shinshu Field - Freestanding chest in front of guardian sapling": LocData(1883647),
-        "Shinshu Field - Freestanding chest near Agata Forest Cave": LocData(1883648),
-        "Shinshu Field - Freestanding chest near Tama's house": LocData(1883669),
-        "Shinshu Field - Buried Chest in burning leaf pile behind Dojo": LocData(1883670, type=LocationType.BURIED_UNDER_LEAF_PILE)
+        "Shinshu Field - Chest on Big Torii": LocData(container_check_id(0xF02, 89), required_brush_techniques=[BrushTechniques.WATERSPOUT]),
+        "Shinshu Field - Freestanding chest in front of guardian sapling": LocData(container_check_id(0xF02, 95)),
+        "Shinshu Field - Freestanding chest near Agata Forest Cave": LocData(container_check_id(0xF02, 96)),
+        "Shinshu Field - Freestanding chest near Tama's house": LocData(container_check_id(0xF02, 117)),
+        "Shinshu Field - Buried Chest in burning leaf pile behind Dojo": LocData(container_check_id(0xF02, 118), type=LocationType.BURIED_UNDER_LEAF_PILE)
     },
 
     RegionNames.TAMA_HOUSE: {
-        "Shinshu Field - Bakigami": LocData(200025,type=LocationType.CONSTELLATION,special_rule=lambda s,w:night_time_check_rule(s,w))  # bit 25
+        "Shinshu Field - Bakigami": LocData(brush_check_id(25),type=LocationType.CONSTELLATION,special_rule=lambda s,w:night_time_check_rule(s,w))  # bit 25
     }
 }
 
-# Shop locations (shopId=18): 300000 + 18*1000 + slot = 318000 + slot
 # These are added separately and conditionally created based on RandomizeShops option
 shop_locations = {
     RegionNames.SHINSHU_FIELD: {
-        "Shinshu Field - Shop Slot 1": LocData(318000, type=LocationType.SHOP),
-        "Shinshu Field - Shop Slot 2": LocData(318001, type=LocationType.SHOP),
-        "Shinshu Field - Shop Slot 3": LocData(318002, type=LocationType.SHOP),
-        "Shinshu Field - Shop Slot 4": LocData(318003, type=LocationType.SHOP),
-        "Shinshu Field - Shop Slot 5": LocData(318004, type=LocationType.SHOP),
-        "Shinshu Field - Shop Slot 6": LocData(318005, type=LocationType.SHOP),
-        "Shinshu Field - Shop Slot 7": LocData(318006, type=LocationType.SHOP),
-        "Shinshu Field - Shop Slot 8": LocData(318007, type=LocationType.SHOP),
-        "Shinshu Field - Shop Slot 9": LocData(318008, type=LocationType.SHOP),
-        "Shinshu Field - Shop Slot 10": LocData(318009, type=LocationType.SHOP),
-        "Shinshu Field - Shop Slot 11": LocData(318010, type=LocationType.SHOP),
-        "Shinshu Field - Shop Slot 12": LocData(318011, type=LocationType.SHOP),
+        "Shinshu Field - Shop Slot 1": LocData(shop_check_id(18, 0), type=LocationType.SHOP),
+        "Shinshu Field - Shop Slot 2": LocData(shop_check_id(18, 1), type=LocationType.SHOP),
+        "Shinshu Field - Shop Slot 3": LocData(shop_check_id(18, 2), type=LocationType.SHOP),
+        "Shinshu Field - Shop Slot 4": LocData(shop_check_id(18, 3), type=LocationType.SHOP),
+        "Shinshu Field - Shop Slot 5": LocData(shop_check_id(18, 4), type=LocationType.SHOP),
+        "Shinshu Field - Shop Slot 6": LocData(shop_check_id(18, 5), type=LocationType.SHOP),
+        "Shinshu Field - Shop Slot 7": LocData(shop_check_id(18, 6), type=LocationType.SHOP),
+        "Shinshu Field - Shop Slot 8": LocData(shop_check_id(18, 7), type=LocationType.SHOP),
+        "Shinshu Field - Shop Slot 9": LocData(shop_check_id(18, 8), type=LocationType.SHOP),
+        "Shinshu Field - Shop Slot 10": LocData(shop_check_id(18, 9), type=LocationType.SHOP),
+        "Shinshu Field - Shop Slot 11": LocData(shop_check_id(18, 10), type=LocationType.SHOP),
+        "Shinshu Field - Shop Slot 12": LocData(shop_check_id(18, 11), type=LocationType.SHOP),
     }
 }

--- a/worlds/okamihd/RegionsData/rf03.py
+++ b/worlds/okamihd/RegionsData/rf03.py
@@ -1,5 +1,6 @@
 from typing import TYPE_CHECKING
 
+from ..CheckIds import container_check_id
 from ..Enums.BrushTechniques import BrushTechniques
 from ..Enums.LocationType import LocationType
 from ..Enums.RegionNames import RegionNames
@@ -19,12 +20,12 @@ events = {
 }
 locations = {
     RegionNames.CURSED_AGATA_FOREST:{
-        "Agata Forest - Burning Chest near Madame Fawn's 1": LocData(1883828,type=LocationType.BURNING_CHEST),
-        "Agata Forest - Burning Chest near Madame Fawn's 2": LocData(1883829,type=LocationType.BURNING_CHEST),
-        "Agata Forest - Burning Chest near Madame Fawn's 3": LocData(1883830,type=LocationType.BURNING_CHEST),
-        "Agata Forest - Ledge chest near Madame Fawn's ": LocData(1883834, required_brush_techniques=[BrushTechniques.WATERSPOUT]),
+        "Agata Forest - Burning Chest near Madame Fawn's 1": LocData(container_check_id(0xF03, 20),type=LocationType.BURNING_CHEST),
+        "Agata Forest - Burning Chest near Madame Fawn's 2": LocData(container_check_id(0xF03, 21),type=LocationType.BURNING_CHEST),
+        "Agata Forest - Burning Chest near Madame Fawn's 3": LocData(container_check_id(0xF03, 22),type=LocationType.BURNING_CHEST),
+        "Agata Forest - Ledge chest near Madame Fawn's ": LocData(container_check_id(0xF03, 26), required_brush_techniques=[BrushTechniques.WATERSPOUT]),
     },
     RegionNames.FAWNS_HOUSE:{
-        "Agata Forest - Stray Bead in Madame Fawn's":LocData(968096)
+        "Agata Forest - Stray Bead in Madame Fawn's":LocData(container_check_id(0x10A, 0))
     }
 }

--- a/worlds/okamihd/RegionsData/rf04.py
+++ b/worlds/okamihd/RegionsData/rf04.py
@@ -1,6 +1,7 @@
 from typing import TYPE_CHECKING
 
 from BaseClasses import LocationProgressType
+from ..CheckIds import brush_check_id, container_check_id
 from ..Enums.BrushTechniques import BrushTechniques
 from ..Enums.LocationType import LocationType
 from ..Enums.OkamiEnemies import OkamiEnemies
@@ -46,42 +47,42 @@ events = {
 locations = {
     RegionNames.AGATA_FOREST: {
         # the names here could be better.
-        "Agata Forest - Treasure Bud near big rocks": LocData(1884064, type=LocationType.TREASURE_BUD),
-        "Agata Forest - Treasure Bud on lone tree island next to big rocks": LocData(1884065, type=LocationType.TREASURE_BUD),
-        "Agata Forest - Treasure Bud near big rocks 2": LocData(1884066, type=LocationType.TREASURE_BUD),
-        "Agata Forest - Treasure Bud on lone tree island near Kokari": LocData(1884067, type=LocationType.TREASURE_BUD),
-        "Agata Forest - Treasure Bud near Karude's house": LocData(1884068, type=LocationType.TREASURE_BUD),
-        "Agata Forest - Treasure Bud near Karude's house cursed patch": LocData(1884069, type=LocationType.TREASURE_BUD),
-        "Agata Forest - Treasure Bud near waterfall": LocData(1884070, type=LocationType.TREASURE_BUD),
-        "Agata Forest - Treasure Bud near Mme. Fawn's Cave": LocData(1884071, type=LocationType.TREASURE_BUD),
-        "Agata Forest - Treasure Bud on center lone tree island": LocData(1884072, type=LocationType.TREASURE_BUD),
-        "Agata Forest - Treasure Bud inside tree at Hitoshio Spring": LocData(1884081, type=LocationType.TREASURE_BUD,required_brush_techniques=[BrushTechniques.GREENSPROUT_BLOOM]),
-        "Agata Forest - Chest at Guardian Sapling": LocData(1884082),
-        "Agata Forest - Buried chest on ledge near Tsuta Ruins Entrance": LocData(1884083, type=LocationType.BURIED_CHEST),
+        "Agata Forest - Treasure Bud near big rocks": LocData(container_check_id(0xF04, 0), type=LocationType.TREASURE_BUD),
+        "Agata Forest - Treasure Bud on lone tree island next to big rocks": LocData(container_check_id(0xF04, 1), type=LocationType.TREASURE_BUD),
+        "Agata Forest - Treasure Bud near big rocks 2": LocData(container_check_id(0xF04, 2), type=LocationType.TREASURE_BUD),
+        "Agata Forest - Treasure Bud on lone tree island near Kokari": LocData(container_check_id(0xF04, 3), type=LocationType.TREASURE_BUD),
+        "Agata Forest - Treasure Bud near Karude's house": LocData(container_check_id(0xF04, 4), type=LocationType.TREASURE_BUD),
+        "Agata Forest - Treasure Bud near Karude's house cursed patch": LocData(container_check_id(0xF04, 5), type=LocationType.TREASURE_BUD),
+        "Agata Forest - Treasure Bud near waterfall": LocData(container_check_id(0xF04, 6), type=LocationType.TREASURE_BUD),
+        "Agata Forest - Treasure Bud near Mme. Fawn's Cave": LocData(container_check_id(0xF04, 7), type=LocationType.TREASURE_BUD),
+        "Agata Forest - Treasure Bud on center lone tree island": LocData(container_check_id(0xF04, 8), type=LocationType.TREASURE_BUD),
+        "Agata Forest - Treasure Bud inside tree at Hitoshio Spring": LocData(container_check_id(0xF04, 17), type=LocationType.TREASURE_BUD,required_brush_techniques=[BrushTechniques.GREENSPROUT_BLOOM]),
+        "Agata Forest - Chest at Guardian Sapling": LocData(container_check_id(0xF04, 18)),
+        "Agata Forest - Buried chest on ledge near Tsuta Ruins Entrance": LocData(container_check_id(0xF04, 19), type=LocationType.BURIED_CHEST),
 
-        "Agata Forest - Chest on top of the big tree at Hitoshio Spring": LocData(1884087, type=LocationType.UNDERWATER_CHEST,
+        "Agata Forest - Chest on top of the big tree at Hitoshio Spring": LocData(container_check_id(0xF04, 23), type=LocationType.UNDERWATER_CHEST,
                                                                required_brush_techniques=[
                                                                    BrushTechniques.GREENSPROUT_VINE]),
-        "Agata Forest - Freestanding stray Bead": LocData(1884088,
+        "Agata Forest - Freestanding stray Bead": LocData(container_check_id(0xF04, 24),
                                                           required_brush_techniques=[BrushTechniques.GREENSPROUT_VINE],
                                                           type=LocationType.FREESTANDING_ITEM),
-        "Agata Forest - Freestanding Bull Horn": LocData(1884089,
+        "Agata Forest - Freestanding Bull Horn": LocData(container_check_id(0xF04, 25),
                                                          required_brush_techniques=[BrushTechniques.GREENSPROUT_VINE],
                                                          type=LocationType.FREESTANDING_ITEM),
-        "Agata Forest - Buried Chest on Lake shore": LocData(1884096, type=LocationType.BURIED_CHEST),
-        "Agata Forest - Buried Chest behind Karude's house": LocData(1884097, type=LocationType.BURIED_CHEST),
-        "Agata Forest - Buried Chest on center lone tree island": LocData(1884098, type=LocationType.BURIED_CHEST),
-        "Agata Forest - Chest under leaf pile near Shinshu Field entrance": LocData(1884107,
+        "Agata Forest - Buried Chest on Lake shore": LocData(container_check_id(0xF04, 32), type=LocationType.BURIED_CHEST),
+        "Agata Forest - Buried Chest behind Karude's house": LocData(container_check_id(0xF04, 33), type=LocationType.BURIED_CHEST),
+        "Agata Forest - Buried Chest on center lone tree island": LocData(container_check_id(0xF04, 34), type=LocationType.BURIED_CHEST),
+        "Agata Forest - Chest under leaf pile near Shinshu Field entrance": LocData(container_check_id(0xF04, 43),
                                                                                     type=LocationType.BURIED_UNDER_LEAF_PILE),
-        "Agata Forest - Buried Chest under leaf pile near shortcut": LocData(1884108, type=LocationType.BURIED_UNDER_LEAF_PILE),
-        "Agata Forest - Chest under leaf pile near river": LocData(1884109, type=LocationType.BURIED_UNDER_LEAF_PILE),
-        "Agata Forest - Buried chest near Tsuta Ruins entrance": LocData(1884110, type=LocationType.STONE_BURIED_CHEST),
-        "Agata Forest - Chest after Bridge cutscene": LocData(1884111,required_items_events=["Agata Forest - Repair Bridge with Kokari"]),
-        "Agata Forest - Chest near Kiba": LocData(1884113),
-        "Agata Forest - Chest near Tusta ruins door": LocData(1884114),
+        "Agata Forest - Buried Chest under leaf pile near shortcut": LocData(container_check_id(0xF04, 44), type=LocationType.BURIED_UNDER_LEAF_PILE),
+        "Agata Forest - Chest under leaf pile near river": LocData(container_check_id(0xF04, 45), type=LocationType.BURIED_UNDER_LEAF_PILE),
+        "Agata Forest - Buried chest near Tsuta Ruins entrance": LocData(container_check_id(0xF04, 46), type=LocationType.STONE_BURIED_CHEST),
+        "Agata Forest - Chest after Bridge cutscene": LocData(container_check_id(0xF04, 47),required_items_events=["Agata Forest - Repair Bridge with Kokari"]),
+        "Agata Forest - Chest near Kiba": LocData(container_check_id(0xF04, 49)),
+        "Agata Forest - Chest near Tusta ruins door": LocData(container_check_id(0xF04, 50)),
         ## Special check
         "Agata Forest - Fish Giant Salmon with Kokari": LocData(77, power_slash_level=1),
-        "Agata Forest - Yumigami": LocData(200018, type=LocationType.CONSTELLATION,  # bit 18
+        "Agata Forest - Yumigami": LocData(brush_check_id(18), type=LocationType.CONSTELLATION,  # bit 18
                                            required_items_events=["Agata Forest - Fish Whopper with Kokari"])
     }
 }

--- a/worlds/okamihd/RegionsData/rf07.py
+++ b/worlds/okamihd/RegionsData/rf07.py
@@ -1,5 +1,6 @@
 from typing import TYPE_CHECKING
 
+from ..CheckIds import container_check_id
 from ..Enums.BrushTechniques import BrushTechniques
 from ..Enums.LocationType import LocationType
 from ..Enums.OkamiEnemies import OkamiEnemies
@@ -34,9 +35,9 @@ events={
 
 locations = {
     RegionNames.CURSED_TAKA_PASS_CAVE:{
-        "Taka pass - Stray bead chest in cave pond" : LocData(1884895, type=LocationType.UNDERWATER_CHEST),
-        "Taka pass - Burning chest in cave upper": LocData(1884841, type=LocationType.BURNING_CHEST),
-        "Taka pass - Second Burning chest in cave upper": LocData(1884847, type=LocationType.BURNING_CHEST_NO_WATER),
+        "Taka pass - Stray bead chest in cave pond" : LocData(container_check_id(0xF07, 63), type=LocationType.UNDERWATER_CHEST),
+        "Taka pass - Burning chest in cave upper": LocData(container_check_id(0xF07, 9), type=LocationType.BURNING_CHEST),
+        "Taka pass - Second Burning chest in cave upper": LocData(container_check_id(0xF07, 15), type=LocationType.BURNING_CHEST_NO_WATER),
     }
 
 }

--- a/worlds/okamihd/RegionsData/rf08.py
+++ b/worlds/okamihd/RegionsData/rf08.py
@@ -1,5 +1,6 @@
 from typing import TYPE_CHECKING
 
+from ..CheckIds import container_check_id, shop_check_id
 from ..Enums.BrushTechniques import BrushTechniques
 from ..Enums.LocationType import LocationType
 from ..Enums.OkamiEnemies import OkamiEnemies
@@ -23,12 +24,12 @@ events={
 locations = {
     RegionNames.TAKA_PASS:{
         "Taka Pass - Chest under leaf pile near Guardian Sapling" : LocData(99, type=LocationType.BURIED_UNDER_LEAF_PILE,required_items_events=["Taka pass - Restore Bridge to Guardian Sapling"]),
-        "Taka Pass - Chest on top of big rock above ledge": LocData(1885088,required_brush_techniques=[BrushTechniques.GREENSPROUT_VINE]),
+        "Taka Pass - Chest on top of big rock above ledge": LocData(container_check_id(0xF08, 0),required_brush_techniques=[BrushTechniques.GREENSPROUT_VINE]),
         "Taka Pass - Chest under leaf pile after cave": LocData(101,type=LocationType.BURIED_UNDER_LEAF_PILE),
         "Taka Pass - Chest under leaf pile near cave west": LocData(102, type=LocationType.BURIED_UNDER_LEAF_PILE),
         "Taka Pass - Chest under leaf pile near Ultimate Origin mirror": LocData(103, type=LocationType.BURIED_UNDER_LEAF_PILE),
-        "Taka Pass - Chest on top of Gutters' House":LocData(1885089,required_brush_techniques=[BrushTechniques.GREENSPROUT_VINE]),
-        "Taka Pass - Chest across banners": LocData(1885091, required_brush_techniques=[BrushTechniques.GREENSPROUT_VINE, BrushTechniques.GALESTORM]),
+        "Taka Pass - Chest on top of Gutters' House":LocData(container_check_id(0xF08, 1),required_brush_techniques=[BrushTechniques.GREENSPROUT_VINE]),
+        "Taka Pass - Chest across banners": LocData(container_check_id(0xF08, 3), required_brush_techniques=[BrushTechniques.GREENSPROUT_VINE, BrushTechniques.GALESTORM]),
         "Taka Pass - Buried chest near Gutters' house":LocData(106,type=LocationType.BURIED_CHEST),
         "Taka Pass - Buried chest near mermaid spring": LocData(107, type=LocationType.BURIED_CHEST),
         "Taka Pass - Buried chest near tea house": LocData(108, type=LocationType.BURIED_CHEST),
@@ -44,21 +45,20 @@ locations = {
 
 }
 
-# Shop locations (shopId=19): 300000 + 19*1000 + slot = 319000 + slot
 # These are added separately and conditionally created based on RandomizeShops option
 shop_locations = {
     RegionNames.TAKA_PASS: {
-        "Taka Pass - Shop Slot 1": LocData(319000, type=LocationType.SHOP),
-        "Taka Pass - Shop Slot 2": LocData(319001, type=LocationType.SHOP),
-        "Taka Pass - Shop Slot 3": LocData(319002, type=LocationType.SHOP),
-        "Taka Pass - Shop Slot 4": LocData(319003, type=LocationType.SHOP),
-        "Taka Pass - Shop Slot 5": LocData(319004, type=LocationType.SHOP),
-        "Taka Pass - Shop Slot 6": LocData(319005, type=LocationType.SHOP),
-        "Taka Pass - Shop Slot 7": LocData(319006, type=LocationType.SHOP),
-        "Taka Pass - Shop Slot 8": LocData(319007, type=LocationType.SHOP),
-        "Taka Pass - Shop Slot 9": LocData(319008, type=LocationType.SHOP),
-        "Taka Pass - Shop Slot 10": LocData(319009, type=LocationType.SHOP),
-        "Taka Pass - Shop Slot 11": LocData(319010, type=LocationType.SHOP),
-        "Taka Pass - Shop Slot 12": LocData(319011, type=LocationType.SHOP),
+        "Taka Pass - Shop Slot 1": LocData(shop_check_id(19, 0), type=LocationType.SHOP),
+        "Taka Pass - Shop Slot 2": LocData(shop_check_id(19, 1), type=LocationType.SHOP),
+        "Taka Pass - Shop Slot 3": LocData(shop_check_id(19, 2), type=LocationType.SHOP),
+        "Taka Pass - Shop Slot 4": LocData(shop_check_id(19, 3), type=LocationType.SHOP),
+        "Taka Pass - Shop Slot 5": LocData(shop_check_id(19, 4), type=LocationType.SHOP),
+        "Taka Pass - Shop Slot 6": LocData(shop_check_id(19, 5), type=LocationType.SHOP),
+        "Taka Pass - Shop Slot 7": LocData(shop_check_id(19, 6), type=LocationType.SHOP),
+        "Taka Pass - Shop Slot 8": LocData(shop_check_id(19, 7), type=LocationType.SHOP),
+        "Taka Pass - Shop Slot 9": LocData(shop_check_id(19, 8), type=LocationType.SHOP),
+        "Taka Pass - Shop Slot 10": LocData(shop_check_id(19, 9), type=LocationType.SHOP),
+        "Taka Pass - Shop Slot 11": LocData(shop_check_id(19, 10), type=LocationType.SHOP),
+        "Taka Pass - Shop Slot 12": LocData(shop_check_id(19, 11), type=LocationType.SHOP),
     }
 }


### PR DESCRIPTION
Update (most) IDs to match what the client will use for v0.8.0+, These new IDs have extended base ranges, so things wont step on each other anymore.

I tried to not make your life hell and have to change everything a third (or fourth?) time. No guarantees I didn't miss something or mess something up though. I avoided the IDs that didn't seem to match with the old system either. 