### PR TITLE
Okami: add traps: inkwell drain, damage, astral pouch drain

### DIFF
--- a/worlds/okamihd/Items.py
+++ b/worlds/okamihd/Items.py
@@ -263,6 +263,11 @@ progressive_weapons = {
     "Progressive Sword": ItemData(0x302, ItemClassification.progression, count_in_pool=0)
 }
 # classified as useful so they're ignored for junk fill
+trap_items = {
+    "Evil Charm":      ItemData(0x400, ItemClassification.trap, count_in_pool=0),
+    "Dry Inkwell":     ItemData(0x401, ItemClassification.trap, count_in_pool=0),
+    "Hungry Spirit":   ItemData(0x402, ItemClassification.trap, count_in_pool=0),
+}
 karmic_transformers = {
     "Karmic Returner": ItemData(0xc8, ItemClassification.useful, count_in_pool=0),
     "Karmic Transformer 1": ItemData(0x5b, ItemClassification.useful, count_in_pool=0),
@@ -288,6 +293,7 @@ item_table = {
     **weapons_items,
     **progressive_weapons,
     **karmic_transformers,
+    **trap_items,
 }
 junk_weights = {
     # TODO: Junk items weight - Based of the number of times it appears in chests in vanilla

--- a/worlds/okamihd/Options.py
+++ b/worlds/okamihd/Options.py
@@ -133,6 +133,21 @@ class ShopSlots(Range):
     range_end = 12
     default = 6
 
+class EnableTraps(Toggle):
+    """Add trap items to the item pool. Traps apply negative effects when received:
+    Evil Charm (damage), Dry Inkwell (ink drain), Hungry Spirit (food drain)."""
+    display_name = "Enable Traps"
+    default = 0
+
+
+class TrapChance(Range):
+    """Percentage of junk (filler) items replaced by traps. Requires Enable Traps."""
+    display_name = "Trap Chance"
+    range_start = 0
+    range_end = 100
+    default = 20
+
+
 class IngredientsInMoonCave(Toggle):
     """Place the 4 ingredients for Orochi's Soup in Moon Cave"""
     display_name="Randomize Ingredients in Moon Cave"
@@ -165,7 +180,9 @@ class OkamiOptions(PerGameCommonOptions):
     CanineRewards: CanineRewards
     MoonCaveAccess: MoonCaveAccess
     BloomGuardianSaplings: BloomGuardianSaplings
-    IngredientsInMoonCave:IngredientsInMoonCave
+    IngredientsInMoonCave: IngredientsInMoonCave
+    EnableTraps: EnableTraps
+    TrapChance: TrapChance
 
 
 #    PraiseSanity:PraiseSanity
@@ -193,6 +210,10 @@ okami_option_groups: Dict[str, List[Any]] = {
         CanineRewards,
         MoonCaveAccess,
         IngredientsInMoonCave
+    ],
+    "Traps": [
+        EnableTraps,
+        TrapChance,
     ]
 
 }

--- a/worlds/okamihd/__init__.py
+++ b/worlds/okamihd/__init__.py
@@ -3,14 +3,14 @@ from BaseClasses import Item, ItemClassification, Tutorial, MultiWorld, Location
 from Utils import visualize_regions
 from .Enums.LocationType import excluded_biteable_location_types
 from .Items import item_table, create_item, create_multiple_items, create_junk_items, get_item_name_to_id_dict, \
-    karmic_transformers, \
+    karmic_transformers, trap_items, \
     progressive_weapons, create_standard_item, create_static_precollected_item_list, global_local_items, \
     soup_ingredient_local_items
 from .Regions import create_regions, get_region_name
 from .Locations import get_location_names, get_total_locations, get_unfilled_locations_count
 from .RegionsData import okami_events, okami_locations, okami_shop_locations
 from .Rules import set_completion_rules
-from .Options import create_option_groups, OkamiOptions, slot_data_options, KarmicTransformers
+from .Options import create_option_groups, OkamiOptions, slot_data_options, KarmicTransformers, EnableTraps
 from worlds.AutoWorld import World, WebWorld, CollectionState
 from typing import List
 from .Types import OkamiItem, resolve_option_callable, LocalItem
@@ -204,6 +204,15 @@ class OkamiWorld(World):
                 itempool += create_multiple_items(self, name, item_count, item_type)
         # Create a number of junk items equal to the locations remaining, minus items that have a fixed count in the item pool, and the locally placed ones.
         junk_fill_count = get_unfilled_locations_count(self) - len(itempool) - len(self.get_local_items_name())
+
+        if self.options.EnableTraps:
+            trap_names = list(trap_items.keys())
+            trap_count = junk_fill_count * self.options.TrapChance.value // 100
+            junk_fill_count -= trap_count
+            for _ in range(trap_count):
+                trap_name = self.random.choice(trap_names)
+                itempool.append(create_item(trap_name, trap_items[trap_name].code, ItemClassification.trap, self))
+
         itempool += create_junk_items(self, junk_fill_count)
 
         for pi in precollected_items:


### PR DESCRIPTION
## What is this fixing or adding?
Adding a first shot at basic traps for Okami & allowing traps into junk slots

## How was this tested?
Tested with client changes, in a test game. Not thoroughly tested with logic slots.