### PR TITLE
[Poc] Use items to unlock mist and mermaid spring warps

### DIFF
--- a/worlds/okamihd/Items.py
+++ b/worlds/okamihd/Items.py
@@ -74,7 +74,6 @@ def create_static_precollected_item_list(world: "OkamiWorld") -> List[Item]:
     return precollected_items
 
 
-
 brush_techniques_items = {
     # Brush Techniques — item codes = 0x100 + game bitfield index (from BrushOverlay enum)
     BrushTechniques.GREENSPROUT_BLOOM.value: ItemData(0x104, ItemClassification.progression),  # bit 4
@@ -117,13 +116,13 @@ equips = {
 
 quest_items = {
     # Quest Items
-    "Canine Tracker": ItemData(0x42, ItemClassification.progression,count_in_pool=0),
+    "Canine Tracker": ItemData(0x42, ItemClassification.progression, count_in_pool=0),
     "Lucky Mallet": ItemData(0x43, ItemClassification.progression),
-    "Border Key": ItemData(0x44, ItemClassification.progression,count_in_pool=0),
-    "Dragon Orb": ItemData(0x45, ItemClassification.progression,count_in_pool=0),
-    "Fox Rods": ItemData(0x46, ItemClassification.progression,count_in_pool=0),
+    "Border Key": ItemData(0x44, ItemClassification.progression, count_in_pool=0),
+    "Dragon Orb": ItemData(0x45, ItemClassification.progression, count_in_pool=0),
+    "Fox Rods": ItemData(0x46, ItemClassification.progression, count_in_pool=0),
     "Thunder Brew": ItemData(0x47, ItemClassification.progression),
-    "Shell Amulet": ItemData(0x48, ItemClassification.progression,count_in_pool=0),
+    "Shell Amulet": ItemData(0x48, ItemClassification.progression, count_in_pool=0),
 
     "Mask": ItemData(0x49, ItemClassification.progression),
     "Golden Mushroom": ItemData(0x5f, ItemClassification.progression),
@@ -132,7 +131,7 @@ quest_items = {
     "Sewaprolo": ItemData(0x63, ItemClassification.progression),
     "Charcoal": ItemData(0x71, ItemClassification.progression),
     "Blinding Snow": ItemData(0x72, ItemClassification.progression),
-    "Treasure Box": ItemData(0x73, ItemClassification.progression,count_in_pool=0),
+    "Treasure Box": ItemData(0x73, ItemClassification.progression, count_in_pool=0),
     "Herbal Medicine": ItemData(0x75, ItemClassification.progression),
     "Pinwheel": ItemData(0x76, ItemClassification.progression),
     "Marlin Rod": ItemData(0x77, ItemClassification.progression),
@@ -152,16 +151,20 @@ bitable_items = {
 }
 useful_items = {
     # Useful items - Counts here are invalid, it's intended, to not fille the item pool with these
-    "Sun Fragment": ItemData(0x05, ItemClassification.useful,count_in_pool=9), # Should be 15
-    "Astral Pouch": ItemData(0x06, ItemClassification.useful,count_in_pool=0),# Intended
-    "Stray Bead": ItemData(0xCC, ItemClassification.useful,count_in_pool=0),# Should be 99, set to 0 for now cause they mess with container collection states
+    "Sun Fragment": ItemData(0x05, ItemClassification.useful, count_in_pool=9),  # Should be 15
+    "Astral Pouch": ItemData(0x06, ItemClassification.useful, count_in_pool=0),  # Intended
+    "Stray Bead": ItemData(0xCC, ItemClassification.useful, count_in_pool=0),
+    # Should be 99, set to 0 for now cause they mess with container collection states
     # probably will have to be changed to progession_skip balancing once DF shops get randomized
     "Demon Fang": ItemData(0x1F, ItemClassification.useful, count_in_pool=0),  # to see when DF shops get randomized
     # Technically a filler item, but useful feels more appropriate. Warping with those without Fountain will probably be out of logic.
-    "Mermaid Coin": ItemData(0x0e, ItemClassification.useful,count_in_pool=5),#Accurate count, kept it since it isn't too much
-    "Golden Peach": ItemData(0x0f, ItemClassification.useful,count_in_pool=10), # 14 in total... Probably not useful to have THAT many?,
-    "Gold Dust": ItemData(0x9e, ItemClassification.useful,count_in_pool=11), # 15 if we count the ones sold by merchants, which we may randomize, only 1 in a chest if we don't count those...
-    "Praise": ItemData(0x59,ItemClassification.useful,count_in_pool=0) #Here for testing for now; Doesn't work
+    "Mermaid Coin": ItemData(0x0e, ItemClassification.useful, count_in_pool=5),
+    # Accurate count, kept it since it isn't too much
+    "Golden Peach": ItemData(0x0f, ItemClassification.useful, count_in_pool=10),
+    # 14 in total... Probably not useful to have THAT many?,
+    "Gold Dust": ItemData(0x9e, ItemClassification.useful, count_in_pool=11),
+    # 15 if we count the ones sold by merchants, which we may randomize, only 1 in a chest if we don't count those...
+    "Praise": ItemData(0x59, ItemClassification.useful, count_in_pool=0)  # Here for testing for now; Doesn't work
 }
 
 filler_items = {
@@ -276,6 +279,42 @@ karmic_transformers = {
     "Karmic Transformer 9": ItemData(0x7c, ItemClassification.useful, count_in_pool=0)
 }
 
+mist_warp_unlocks = {
+    # MIST WARPS POINTS
+    "Mist Warp Unlock - Kamiki Village": ItemData(0x500, ItemClassification.progression),
+    "Mist Warp Unlock - Shinshu Field": ItemData(0x501, ItemClassification.progression),
+    "Mist Warp Unlock - Cursed Agata Forest": ItemData(0x502, ItemClassification.progression),
+    "Mist Warp Unlock - Cursed Taka Pass": ItemData(0x503, ItemClassification.progression),
+    "Mist Warp Unlock - Kusa Village": ItemData(0x504, ItemClassification.progression),
+    "Mist Warp Unlock - Sasa Sanctuary": ItemData(0x505, ItemClassification.progression),
+    "Mist Warp Unlock - City Checkpoint": ItemData(0x506, ItemClassification.progression),
+    "Mist Warp Unlock - Cursed Ryoshima Coast": ItemData(0x507, ItemClassification.progression),
+    "Mist Warp Unlock - North Ryoshima Coast": ItemData(0x508, ItemClassification.progression),
+    "Mist Warp Unlock - North Ryoshima Coast (Rocky Area)": ItemData(0x509, ItemClassification.progression),
+    "Mist Warp Unlock - Dragon Palace": ItemData(0x50A, ItemClassification.progression),
+    ## ARC 3 WARPS
+    # "Mist Warp Unlock - Kamui": ItemData(0x50B, ItemClassification.progression),
+    # "Mist Warp Unlock - Wep'keer": ItemData(0x50C, ItemClassification.progression),
+    # "Mist Warp Unlock - Inner Yoshpet": ItemData(0x50D, ItemClassification.progression),
+    # "Mist Warp Unlock - Kamui(Ezofuji - Rocky Area)": ItemData(0x50E, ItemClassification.progression),
+
+}
+mermaid_spring_unlocks = {
+
+    # MERMAID SPRINGS
+    "Mermaid Sping Unlock - Shinshu Field": ItemData(0x510, ItemClassification.progression),
+    "Mermaid Sping Unlock - Agata Forest": ItemData(0x511, ItemClassification.progression),
+    "Mermaid Sping Unlock - Taka Pass": ItemData(0x512, ItemClassification.progression),
+    "Mermaid Sping Unlock - Sasa Sanctuary": ItemData(0x513, ItemClassification.progression),
+    "Mermaid Sping Unlock - Ryoshima Coast": ItemData(0x514, ItemClassification.progression),
+    "Mermaid Sping Unlock - Sei-an City": ItemData(0x515, ItemClassification.progression),
+    "Mermaid Sping Unlock - Northen Ryoshima Coast": ItemData(0x516, ItemClassification.progression),
+    "Mermaid Sping Unlock - Catcall Tower": ItemData(0x517, ItemClassification.progression),
+    "Mermaid Sping Unlock - Dragon Palace": ItemData(0x518, ItemClassification.progression),
+    ## ARC 3 SPRINGS
+    # "Mermaid Sping Unlock - Kamui": ItemData(0x519, ItemClassification.progression),
+}
+
 item_table = {
     **brush_techniques_items,
     **equips,
@@ -288,6 +327,8 @@ item_table = {
     **weapons_items,
     **progressive_weapons,
     **karmic_transformers,
+    **mist_warp_unlocks,
+    **mermaid_spring_unlocks
 }
 junk_weights = {
     # TODO: Junk items weight - Based of the number of times it appears in chests in vanilla

--- a/worlds/okamihd/RegionsData/r102.py
+++ b/worlds/okamihd/RegionsData/r102.py
@@ -1,7 +1,7 @@
 from typing import TYPE_CHECKING
 
 from BaseClasses import LocationProgressType
-from rule_builder.rules import True_
+from rule_builder.rules import True_, Has
 from ..CheckIds import brush_check_id, collected_object_check_id, container_check_id, shop_check_id
 from ..Enums.BrushTechniques import BrushTechniques
 from ..Enums.LocationType import LocationType
@@ -16,20 +16,23 @@ if TYPE_CHECKING:
 
 exits = {
     RegionNames.STONE_KAMIKI: [
-        ExitData(RegionNames.KAMIKI_VILLAGE, required_items_events=["Kamiki Village - Fight with Mr.Orange"], one_way=True)],
+        ExitData(RegionNames.KAMIKI_VILLAGE, required_items_events=["Kamiki Village - Fight with Mr.Orange"],
+                 one_way=True)],
     RegionNames.KAMIKI_VILLAGE: [ExitData(RegionNames.KAMIKI_ISLANDS, needs_long_swim=True, loading_screen=False),
                                  ExitData(RegionNames.SUSANOS_HOUSE),
                                  ExitData(RegionNames.KUSHIS_HOUSE),
                                  ExitData(RegionNames.ORANGES_HOUSE),
                                  ExitData(RegionNames.RIVER_OF_THE_HEAVENS_KAMIKI),
                                  ExitData(RegionNames.CURSED_SHINSHU_FIELD,
-                                          required_items_events=["Kamiki Village - Help Susano Train/Break the boulder"]),
+                                          required_items_events=[
+                                              "Kamiki Village - Help Susano Train/Break the boulder"]),
                                  ExitData(RegionNames.SHINSHU_FIELD,
                                           required_items_events=["Kamiki Village - Help Susano Train/Break the boulder",
-                                                      "Shinshu Field - Restore Guardian Sapling"]),
+                                                                 "Shinshu Field - Restore Guardian Sapling"]),
                                  # One way bc this is not a logical access.
                                  ExitData(RegionNames.KAMIKI_MERCHANT,
-                                          required_items_events=["Kamiki Village - Help Susano Train/Break the boulder"],
+                                          required_items_events=[
+                                              "Kamiki Village - Help Susano Train/Break the boulder"],
                                           one_way=True, loading_screen=False)],
     RegionNames.SUSANOS_HOUSE: [ExitData(RegionNames.SUSANOS_UNDERGROUD)]
 }
@@ -77,7 +80,8 @@ events = {
 }
 locations = {
     RegionNames.STONE_KAMIKI: {
-        "Kamiki Village - Sunrise": LocData(brush_check_id(27), type=LocationType.CONSTELLATION,progress_type=LocationProgressType.EXCLUDED),
+        "Kamiki Village - Sunrise": LocData(brush_check_id(27), type=LocationType.CONSTELLATION,
+                                            progress_type=LocationProgressType.EXCLUDED),
         # Brush acquisition (bit 27)
     },
     RegionNames.KAMIKI_VILLAGE: {
@@ -96,7 +100,9 @@ locations = {
             container_check_id(MapIds.KAMIKI_VILLAGE, 32), type=LocationType.UNDERWATER_CHEST),  # spawn_idx=32, Vase
         "Kamiki Village - Hasugami": LocData(brush_check_id(5),
                                              required_items_events=["Kamiki Village - Restore Sakuya's Tree"],
-                                             type=LocationType.CONSTELLATION,progress_type=LocationProgressType.EXCLUDED),  # Brush acquisition (Waterlily)
+                                             type=LocationType.CONSTELLATION,
+                                             progress_type=LocationProgressType.EXCLUDED),
+        # Brush acquisition (Waterlily)
         "Kamiki Village - Buried chest in field": LocData(container_check_id(MapIds.KAMIKI_VILLAGE, 13),
                                                           type=LocationType.BURIED_CHEST),
         # spawn_idx=13, Dragonfly Bead
@@ -126,7 +132,8 @@ locations = {
         # Kushi's Gift is not a container - it's an event/NPC reward. Keep old ID for now.
         "Kamiki Village - Kushi's Gift": LocData(collected_object_check_id(MapIndexes.KAMIKI_VILLAGE, 11),
                                                  # mapId=3 (KamikiVillage enum index)
-                                                 required_items_events=["Kamiki Village - Repair Kushi's Watermill"],progress_type=LocationProgressType.EXCLUDED),
+                                                 required_items_events=["Kamiki Village - Repair Kushi's Watermill"],
+                                                 progress_type=LocationProgressType.EXCLUDED),
     },
     RegionNames.KAMIKI_ISLANDS: {
         "Kamiki Village - East Islands Sun fragment chest": LocData(container_check_id(MapIds.KAMIKI_VILLAGE, 42)),
@@ -160,6 +167,6 @@ shop_locations = {
 
 warps = {
     RegionNames.STONE_KAMIKI: [
-        WarpData(type=WarpType.MIST_WARP, trigger_warp_to=True_, trigger_warp_from=True_)
+        WarpData(type=WarpType.MIST_WARP, trigger_warp_to=Has("Mist Warp Unlock - Kamiki Village"), trigger_warp_from=True_)
     ]
 }

--- a/worlds/okamihd/RegionsData/r105.py
+++ b/worlds/okamihd/RegionsData/r105.py
@@ -98,6 +98,6 @@ shop_locations = {
 
 warps = {
     RegionNames.CITY_CHECKPOINT_TAKA: [
-        WarpData(type=WarpType.MIST_WARP, trigger_warp_to=True_, trigger_warp_from=True_)
+        WarpData(type=WarpType.MIST_WARP, trigger_warp_to=Has("Mist Warp Unlock - City Checkpoint"), trigger_warp_from=True_)
     ]
 }

--- a/worlds/okamihd/RegionsData/r108.py
+++ b/worlds/okamihd/RegionsData/r108.py
@@ -1,7 +1,7 @@
 from typing import TYPE_CHECKING
 
 from BaseClasses import LocationProgressType
-from rule_builder.rules import True_
+from rule_builder.rules import True_, Has
 from ..CheckIds import container_check_id, shop_check_id
 from ..Enums.BrushTechniques import BrushTechniques
 from ..Enums.LocationType import LocationType
@@ -119,6 +119,6 @@ shop_locations = {
 
 warps = {
     RegionNames.KUSA_VILLAGE: [
-        WarpData(type=WarpType.MIST_WARP, trigger_warp_to=True_, trigger_warp_from=True_)
+        WarpData(type=WarpType.MIST_WARP, trigger_warp_to=Has("Mist Warp Unlock - Kusa Village"), trigger_warp_from=True_)
     ]
 }

--- a/worlds/okamihd/RegionsData/r109.py
+++ b/worlds/okamihd/RegionsData/r109.py
@@ -81,9 +81,9 @@ shop_locations={
 
 warps={
     RegionNames.SASA_SANCTUARY:[
-        WarpData(type=WarpType.MERMAID_SPRING, trigger_warp_to=Has( "Sasa Sanctuary - Dig with Mr. Bamboo."), trigger_warp_from=Has( "Sasa Sanctuary - Dig with Mr. Bamboo."))
+        WarpData(type=WarpType.MERMAID_SPRING, trigger_warp_to=Has("Mermaid Sping Unlock - Sasa Sanctuary"), trigger_warp_from=Has( "Sasa Sanctuary - Dig with Mr. Bamboo."))
     ],
     RegionNames.SASA_SANCTUARY_ENTRANCE:[
-        WarpData(type=WarpType.MIST_WARP, trigger_warp_to=True_, trigger_warp_from=True_),
+        WarpData(type=WarpType.MIST_WARP, trigger_warp_to=Has("Mist Warp Unlock - Sasa Sanctuary"), trigger_warp_from=True_),
     ]
 }

--- a/worlds/okamihd/RegionsData/r200.py
+++ b/worlds/okamihd/RegionsData/r200.py
@@ -180,7 +180,7 @@ locations = {
 }
 warps = {
     RegionNames.SEIAN_CITY_ARISTOCRATIC: [
-        WarpData(WarpType.MERMAID_SPRING, Has("Imperial Palace - Defeat Blight"),
+        WarpData(WarpType.MERMAID_SPRING, Has("Mermaid Sping Unlock - Sei-an City"),
                  Has("Imperial Palace - Defeat Blight"))
     ]
 }

--- a/worlds/okamihd/RegionsData/r203.py
+++ b/worlds/okamihd/RegionsData/r203.py
@@ -1,7 +1,7 @@
 from typing import TYPE_CHECKING
 
 from BaseClasses import LocationProgressType
-from rule_builder.rules import Has
+from rule_builder.rules import Has, True_
 from ..CheckIds import container_check_id, shop_check_id, brush_check_id
 from ..Enums.BrushTechniques import BrushTechniques
 from ..Enums.LocationType import LocationType
@@ -18,7 +18,8 @@ exits = {
                  required_items_events=["Dragon Palace - Get Shell Amulet from Otohime"]),
         ExitData(RegionNames.DRAGON_PALACE_GARDEN, one_way=True,
                  required_items_events=["Dragon Palace - Get Shell Amulet from Otohime"]),
-        ExitData(RegionNames.DRAGON_PALACE_CAVE, required_items_events=["Dragon Palace - Open Treasure Cave behind stairs"])
+        ExitData(RegionNames.DRAGON_PALACE_CAVE,
+                 required_items_events=["Dragon Palace - Open Treasure Cave behind stairs"])
     ],
     RegionNames.DRAGON_PALACE_SPRING: [
         ExitData(RegionNames.DRAGON_PALACE, one_way=True)
@@ -34,7 +35,8 @@ events = {
         # FIXME: This should give shell amulet, and it should be removed from pool since it can't be picked up rn
         # FIXME: Change this to a location later
         "Dragon Palace - Get Shell Amulet from Otohime": EventData(),
-        "Dragon Palace - Give Dragon Orb to Otohime": EventData(required_items_events=["Inside the dragon - Get Dragon Orb"])
+        "Dragon Palace - Give Dragon Orb to Otohime": EventData(
+            required_items_events=["Inside the dragon - Get Dragon Orb"])
     },
     RegionNames.DRAGON_PALACE_SPRING: {
         "Dragon Palace - Restore the soothing spring": EventData(type=LocationType.DIGGING_MINIGAME_HARD,
@@ -87,7 +89,10 @@ shop_locations = {
 }
 warps = {
     RegionNames.DRAGON_PALACE_SPRING: [
-        WarpData(WarpType.MERMAID_SPRING, Has("Dragon Palace - Restore the soothing spring"),
+        WarpData(WarpType.MERMAID_SPRING, Has("Mermaid Sping Unlock - Dragon Palace"),
                  Has("Dragon Palace - Restore the soothing spring"))
+    ],
+    RegionNames.DRAGON_PALACE: [
+        WarpData(WarpType.MIST_WARP, Has("Mist Warp Unlock - Dragon Palace"), True_)
     ]
 }

--- a/worlds/okamihd/RegionsData/r20a.py
+++ b/worlds/okamihd/RegionsData/r20a.py
@@ -55,6 +55,6 @@ locations = {
 }
 warps = {
     RegionNames.CATCALL_TOWER_TOP: [
-        WarpData(WarpType.MERMAID_SPRING, Has("Catcall Tower - Unlock warp"), Has("Catcall Tower - Unlock warp"))
+        WarpData(WarpType.MERMAID_SPRING, Has("Mermaid Sping Unlock - Catcall Tower"), Has("Catcall Tower - Unlock warp"))
     ]
 }

--- a/worlds/okamihd/RegionsData/rf02.py
+++ b/worlds/okamihd/RegionsData/rf02.py
@@ -16,16 +16,19 @@ if TYPE_CHECKING:
 
 exits = {
     RegionNames.SHINSHU_FIELD: [
-        ExitData(RegionNames.SHINSHU_LOGIC_COMMON,one_way=True,loading_screen=False),
+        ExitData(RegionNames.SHINSHU_LOGIC_COMMON, one_way=True, loading_screen=False),
         ExitData(RegionNames.SHINSHU_FIELD_AGATA_CAVE, needs_long_swim=True, loading_screen=False),
         ExitData(RegionNames.TAMA_HOUSE),
         ExitData(RegionNames.MOON_CAVE_OUTSIDE),
-        ExitData(RegionNames.SHINSHU_PLATEAU, required_items_events=["Shinshu Field - Climb on plateau"], loading_screen=False)],
+        ExitData(RegionNames.SHINSHU_PLATEAU, required_items_events=["Shinshu Field - Climb on plateau"],
+                 loading_screen=False)],
     RegionNames.SHINSHU_FIELD_AGATA_CAVE: [ExitData(RegionNames.CURSED_AGATA_FOREST,
-                                                    required_items_events=["Shinshu Field - Open Entrance to Agata Forest"]),
+                                                    required_items_events=[
+                                                        "Shinshu Field - Open Entrance to Agata Forest"]),
                                            ExitData(RegionNames.AGATA_FOREST,
-                                                    required_items_events=["Shinshu Field - Open Entrance to Agata Forest",
-                                                                "Agata Forest - Restore Guardian Sapling"]),
+                                                    required_items_events=[
+                                                        "Shinshu Field - Open Entrance to Agata Forest",
+                                                        "Agata Forest - Restore Guardian Sapling"]),
                                            ],
     RegionNames.SHINSHU_AGATA_SHORTCUT_LEDGE: [ExitData(RegionNames.SHINSHU_FIELD, one_way=True, loading_screen=False)]
 }
@@ -35,7 +38,8 @@ events = {
     },
     RegionNames.SHINSHU_FIELD: {
         "Shinshu Field - Climb on plateau": EventData(required_items_events=[BrushTechniques.CATWALK]),
-        "Shinshu Field - Clear Devil gate near Dojo": EventData(mandatory_enemies=[OkamiEnemies.YELLOW_IMP,OkamiEnemies.GREEN_IMP])
+        "Shinshu Field - Clear Devil gate near Dojo": EventData(
+            mandatory_enemies=[OkamiEnemies.YELLOW_IMP, OkamiEnemies.GREEN_IMP])
     }
 }
 locations = {
@@ -84,7 +88,8 @@ locations = {
 
     RegionNames.TAMA_HOUSE: {
         "Shinshu Field - Bakugami": LocData(brush_check_id(25), type=LocationType.CONSTELLATION,
-                                            special_rule=night_time_check_rule,progress_type=LocationProgressType.EXCLUDED)  # bit 25
+                                            special_rule=night_time_check_rule,
+                                            progress_type=LocationProgressType.EXCLUDED)  # bit 25
     },
 
     RegionNames.SHINSHU_PLATEAU: {
@@ -119,8 +124,9 @@ shop_locations = {
 
 warps = {
     RegionNames.SHINSHU_FIELD: [
-        WarpData(type=WarpType.MIST_WARP, trigger_warp_to=True_, trigger_warp_from=True_),
-        WarpData(type=WarpType.MERMAID_SPRING, trigger_warp_to=Has("Shinshu Field - Clear Devil gate near Dojo"),
+        WarpData(type=WarpType.MIST_WARP, trigger_warp_to=Has("Mist Warp Unlock - Shinshu Field"),
+                 trigger_warp_from=True_),
+        WarpData(type=WarpType.MERMAID_SPRING, trigger_warp_to=Has("Mermaid Sping Unlock - Shinshu Field"),
                  trigger_warp_from=Has("Shinshu Field - Clear Devil gate near Dojo"))
     ]
 }

--- a/worlds/okamihd/RegionsData/rf03.py
+++ b/worlds/okamihd/RegionsData/rf03.py
@@ -1,6 +1,6 @@
 from typing import TYPE_CHECKING
 
-from rule_builder.rules import True_
+from rule_builder.rules import True_, Has
 from ..CheckIds import container_check_id
 from ..Enums.BrushTechniques import BrushTechniques
 from ..Enums.LocationType import LocationType
@@ -42,6 +42,6 @@ locations = {
 }
 warps = {
     RegionNames.CURSED_AGATA_FOREST: [
-        WarpData(type=WarpType.MIST_WARP, trigger_warp_to=True_, trigger_warp_from=True_),
+        WarpData(type=WarpType.MIST_WARP, trigger_warp_to=Has("Mist Warp Unlock - Cursed Agata Forest"), trigger_warp_from=True_),
     ]
 }

--- a/worlds/okamihd/RegionsData/rf04.py
+++ b/worlds/okamihd/RegionsData/rf04.py
@@ -147,7 +147,7 @@ shop_locations = {
 }
 warps = {
     RegionNames.AGATA_FOREST: [
-        WarpData(type=WarpType.MERMAID_SPRING, trigger_warp_to=Has("Agata Forest - Unlock Mermaid Spring"),
+        WarpData(type=WarpType.MERMAID_SPRING, trigger_warp_to=Has("Mermaid Sping Unlock - Agata Forest"),
                  trigger_warp_from=Has("Agata Forest - Unlock Mermaid Spring"))
     ]
 }

--- a/worlds/okamihd/RegionsData/rf07.py
+++ b/worlds/okamihd/RegionsData/rf07.py
@@ -1,6 +1,6 @@
 from typing import TYPE_CHECKING
 
-from rule_builder.rules import True_
+from rule_builder.rules import True_, Has
 from ..CheckIds import container_check_id
 from ..Enums.BrushTechniques import BrushTechniques
 from ..Enums.LocationType import LocationType
@@ -61,6 +61,6 @@ locations = {
 
 warps = {
     RegionNames.CURSED_TAKA_PASS: [
-        WarpData(type=WarpType.MIST_WARP, trigger_warp_to=True_, trigger_warp_from=True_)
+        WarpData(type=WarpType.MIST_WARP, trigger_warp_to=Has("Mist Warp Unlock - Cursed Taka Pass"), trigger_warp_from=True_)
     ]
 }

--- a/worlds/okamihd/RegionsData/rf08.py
+++ b/worlds/okamihd/RegionsData/rf08.py
@@ -99,7 +99,7 @@ shop_locations = {
 
 warps = {
     RegionNames.TAKA_PASS: [
-        WarpData(type=WarpType.MERMAID_SPRING, trigger_warp_to=Has("Taka Pass - Clear Devil gate near waterfall"),
+        WarpData(type=WarpType.MERMAID_SPRING, trigger_warp_to=Has("Mermaid Sping Unlock - Taka Pass"),
                  trigger_warp_from=Has("Taka Pass - Clear Devil gate near waterfall"))
     ]
 }

--- a/worlds/okamihd/RegionsData/rf09.py
+++ b/worlds/okamihd/RegionsData/rf09.py
@@ -1,6 +1,6 @@
 from typing import TYPE_CHECKING
 
-from rule_builder.rules import True_
+from rule_builder.rules import True_, Has
 from ..Enums.BrushTechniques import BrushTechniques
 from ..Enums.WarpType import WarpType
 from ..Types import ExitData, EventData, WarpData
@@ -34,6 +34,6 @@ locations = {
 }
 warps = {
     RegionNames.CURSED_RYOSHIMA_COAST: [
-        WarpData(type=WarpType.MIST_WARP, trigger_warp_to=True_, trigger_warp_from=True_)
+        WarpData(type=WarpType.MIST_WARP, trigger_warp_to=Has("Mist Warp Unlock - Cursed Ryoshima Coast"), trigger_warp_from=True_)
     ]
 }

--- a/worlds/okamihd/RegionsData/rf0a.py
+++ b/worlds/okamihd/RegionsData/rf0a.py
@@ -210,7 +210,7 @@ shop_locations = {
 warps = {
     RegionNames.RYOSHIMA_COAST: [
         WarpData(type=WarpType.MERMAID_SPRING,
-                 trigger_warp_to=Has("Ryoshima Coast - Clear Devil Gate near North Ryoshima Coast Entrance"),
+                 trigger_warp_to=Has("Mermaid Sping Unlock - Ryoshima Coast"),
                  trigger_warp_from=Has("Ryoshima Coast - Clear Devil Gate near North Ryoshima Coast Entrance")),
     ]
 }

--- a/worlds/okamihd/RegionsData/rf0c.py
+++ b/worlds/okamihd/RegionsData/rf0c.py
@@ -1,6 +1,6 @@
 from typing import TYPE_CHECKING
 
-from rule_builder.rules import Has, Or
+from rule_builder.rules import Has, Or, True_
 from ..CheckIds import shop_check_id, container_check_id, brush_check_id
 from ..Enums.BrushTechniques import BrushTechniques
 from ..Enums.LocationType import LocationType
@@ -233,13 +233,13 @@ locations = {
 }
 warps = {
     RegionNames.NORTHERN_RYOSHIMA_COAST: [
-        WarpData(WarpType.MIST_WARP, Has("Northern Ryoshima Coast - Unlock Warp Points"),
-                 Has("Northern Ryoshima Coast - Unlock Warp Points")),
-        WarpData(WarpType.MERMAID_SPRING, Has("Northern Ryoshima Coast - Unlock Warp Points"),
-                 Has("Northern Ryoshima Coast - Unlock Warp Points"))
+        WarpData(WarpType.MIST_WARP, Has("Mist Warp Unlock - North Ryoshima Coast"),
+                 True_),
+        WarpData(WarpType.MERMAID_SPRING, Has("Mist Warp Unlock - North Ryoshima Coast (Rocky Area)"),
+                 True_)
     ],
     RegionNames.NORTHERN_RYOSHIMA_COAST_MIST_WARP: [
-        WarpData(WarpType.MIST_WARP, Has("Northern Ryoshima Coast - Unlock Warp Points"),
+        WarpData(WarpType.MIST_WARP, Has("Mermaid Sping Unlock - Northen Ryoshima Coast"),
                  Has("Northern Ryoshima Coast - Unlock Warp Points"))
     ]
 }

--- a/worlds/okamihd/__init__.py
+++ b/worlds/okamihd/__init__.py
@@ -5,7 +5,7 @@ from .Enums.LocationType import excluded_biteable_location_types
 from .Items import item_table, create_item, create_multiple_items, create_junk_items, get_item_name_to_id_dict, \
     karmic_transformers, \
     progressive_weapons, create_standard_item, create_static_precollected_item_list, global_local_items, \
-    soup_ingredient_local_items
+    soup_ingredient_local_items, mist_warp_unlocks, mermaid_spring_unlocks
 from .Regions import create_regions, get_region_name
 from .Locations import get_location_names, get_total_locations, get_unfilled_locations_count
 from .RegionsData import okami_events, okami_locations, okami_shop_locations
@@ -31,6 +31,7 @@ class OkamiWebWolrd(WebWorld):
     )]
 
 
+
 class OkamiWorld(World):
     """
     Okami HD
@@ -43,6 +44,8 @@ class OkamiWorld(World):
     options: OkamiOptions
     web = OkamiWebWolrd()
     local_items = []
+    initial_mist_warp = None
+    initial_mermaid_spring = None
 
     def __init__(self, multiworld: "MultiWorld", player: int):
         super().__init__(multiworld, player)
@@ -52,10 +55,11 @@ class OkamiWorld(World):
 
         create_regions(self)
         # DEBUG
-        #visualize_regions(self.multiworld.get_region("Menu", self.player),"G:\projets\OkamiAP\worlds\okamihd\docs\OkamiHD.puml")
+        # visualize_regions(self.multiworld.get_region("Menu", self.player),"G:\projets\OkamiAP\worlds\okamihd\docs\OkamiHD.puml")
 
     def create_items(self):
         self.prepare_local_items()
+        self.prepare_starting_warps()
         self.multiworld.itempool += self.create_itempool()
 
     def prepare_local_items(self):
@@ -84,6 +88,26 @@ class OkamiWorld(World):
             slot_data[name] = value
 
         return slot_data
+
+
+    # Give the player 1 mermaid sping and 1 mist warp point, so they can get some use of the powers when they unlock them
+    def prepare_starting_warps(self):
+        mist_warps = list(mist_warp_unlocks.keys()).copy()
+        self.random.shuffle(mist_warps)
+        self.initial_mist_warp = mist_warps[0]
+
+        mermaid_springs = list(mermaid_spring_unlocks.keys()).copy()
+        self.random.shuffle(mermaid_springs)
+        self.initial_mermaid_spring = mermaid_springs[0]
+
+        mist_warp_entry = mist_warp_unlocks.get(self.initial_mist_warp)
+        self.push_precollected(create_item(self.initial_mist_warp,mist_warp_entry.code,mist_warp_entry.classification,self))
+
+        mermaid_spring_entry = mermaid_spring_unlocks.get(self.initial_mermaid_spring)
+        self.push_precollected(
+            create_item(self.initial_mermaid_spring, mermaid_spring_entry.code, mermaid_spring_entry.classification, self))
+
+
 
     def get_local_items_name(self) -> List[str]:
         local_items_names: List[str] = []
@@ -197,8 +221,8 @@ class OkamiWorld(World):
         for name in item_table.keys():
             item_type: ItemClassification = item_table.get(name).classification
             item_count: int = resolve_option_callable(item_table.get(name).count_in_pool, self)
-            # If the item is locally randomized we have to put one less
-            if name in self.get_local_items_name():
+            # If the item is locally randomized or precollected we have to put one less
+            if (name in self.get_local_items_name() ) or name == self.initial_mermaid_spring or name == self.initial_mist_warp :
                 item_count -= 1
             if item_type != ItemClassification.filler and item_count > 0:
                 itempool += create_multiple_items(self, name, item_count, item_type)


### PR DESCRIPTION
Add items for warps unlocks:
0x50x => Mist warps
0x51x => Mermaid spings

Give the player 1 of each at start, so they get some value when obtaining fountain/mist warp.

## Missing 
- Client integration  
- Add new checks when unlocking mist and mermaid spring warps.


Stays in draft while waiting for the first one